### PR TITLE
Add support for the power mode handling.

### DIFF
--- a/config/gateway1.yaml
+++ b/config/gateway1.yaml
@@ -66,6 +66,30 @@ gateway:
       0x7E: "Sub-function not supported in active session"
       0x7F: "Service not supported in active session"
 
+  # Power Mode Status Configuration
+  power_mode_status:
+    description: "Power mode status values for DoIP power mode response (payload type 0x0008)"
+    current_status: 0x0001  # Current power mode status (2 bytes)
+    available_statuses:
+      0x0000: 
+        name: "Power Off"
+        description: "ECU is powered off"
+      0x0001:
+        name: "Power On"
+        description: "ECU is powered on and ready"
+      0x0002:
+        name: "Power Standby"
+        description: "ECU is in standby mode"
+      0x0003:
+        name: "Power Sleep"
+        description: "ECU is in sleep mode"
+      0x0004:
+        name: "Power Wake"
+        description: "ECU is waking up"
+    response_cycling:
+      enabled: false  # Enable cycling through different power mode statuses
+      cycle_through: [0x0001, 0x0002, 0x0003]  # Statuses to cycle through
+
 # Logging Configuration
 logging:
   level: "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/src/doip_server/hierarchical_config_manager.py
+++ b/src/doip_server/hierarchical_config_manager.py
@@ -416,6 +416,10 @@ gateway:
             "description": gateway_config.get("description", ""),
         }
 
+    def get_power_mode_config(self) -> Dict[str, Any]:
+        """Get power mode status configuration"""
+        return self.get_gateway_config().get("power_mode_status", {})
+
     # ECU configuration methods
     def get_all_ecu_addresses(self) -> List[int]:
         """Get all configured ECU target addresses.

--- a/tests/test_power_mode.py
+++ b/tests/test_power_mode.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""
+Tests for power mode functionality in DoIP server.
+Tests power mode request handling, response generation, and configuration.
+"""
+
+import pytest
+import struct
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add the src directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from doip_server.doip_server import DoIPServer
+from doip_server.hierarchical_config_manager import HierarchicalConfigManager
+
+
+class TestPowerModeConfiguration:
+    """Test power mode configuration loading and management"""
+
+    def test_power_mode_config_loading(self):
+        """Test that power mode configuration is properly loaded from YAML"""
+        config_manager = HierarchicalConfigManager("config/gateway1.yaml")
+        power_config = config_manager.get_power_mode_config()
+
+        # Verify configuration structure
+        assert isinstance(power_config, dict)
+        assert "current_status" in power_config
+        assert "available_statuses" in power_config
+        assert "response_cycling" in power_config
+
+        # Verify current status
+        assert power_config["current_status"] == 0x0001  # Power On
+
+        # Verify available statuses
+        available_statuses = power_config["available_statuses"]
+        assert len(available_statuses) == 5
+        assert 0x0000 in available_statuses  # Power Off
+        assert 0x0001 in available_statuses  # Power On
+        assert 0x0002 in available_statuses  # Power Standby
+        assert 0x0003 in available_statuses  # Power Sleep
+        assert 0x0004 in available_statuses  # Power Wake
+
+        # Verify status details
+        power_on_status = available_statuses[0x0001]
+        assert power_on_status["name"] == "Power On"
+        assert power_on_status["description"] == "ECU is powered on and ready"
+
+        # Verify response cycling configuration
+        response_cycling = power_config["response_cycling"]
+        assert response_cycling["enabled"] == False
+        assert response_cycling["cycle_through"] == [0x0001, 0x0002, 0x0003]
+
+    def test_power_mode_config_fallback(self):
+        """Test power mode configuration fallback when config is missing"""
+        # Create a config manager with a non-existent config file
+        config_manager = HierarchicalConfigManager("non_existent_config.yaml")
+        power_config = config_manager.get_power_mode_config()
+
+        # Should return empty dict when config is missing
+        assert power_config == {}
+
+    def test_power_mode_config_with_custom_values(self):
+        """Test power mode configuration with custom values"""
+        # Create a temporary config file with custom power mode settings
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0002,  # Power Standby
+                    "available_statuses": {
+                        0x0002: {
+                            "name": "Custom Standby",
+                            "description": "Custom standby mode",
+                        }
+                    },
+                    "response_cycling": {"enabled": True, "cycle_through": [0x0002]},
+                },
+            }
+        }
+
+        # Create a config manager and manually set the config
+        config_manager = HierarchicalConfigManager()
+        config_manager.gateway_config = custom_config
+        power_config = config_manager.get_power_mode_config()
+
+        assert power_config["current_status"] == 0x0002
+        assert power_config["response_cycling"]["enabled"] == True
+        assert power_config["response_cycling"]["cycle_through"] == [0x0002]
+
+
+class TestPowerModeResponseGeneration:
+    """Test power mode response generation functionality"""
+
+    def test_create_power_mode_response_default(self):
+        """Test power mode response creation with default configuration"""
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+        response = server.create_power_mode_response()
+
+        # Verify response structure
+        assert len(response) == 10  # 8 bytes header + 2 bytes payload
+
+        # Verify DoIP header
+        assert response[0] == 0x02  # Protocol version
+        assert response[1] == 0xFD  # Inverse protocol version
+        assert struct.unpack(">H", response[2:4])[0] == 0x0008  # Payload type
+        assert struct.unpack(">I", response[4:8])[0] == 2  # Payload length
+
+        # Verify power mode status (should be 0x0001 - Power On)
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x0001
+
+    def test_create_power_mode_response_custom_status(self):
+        """Test power mode response creation with custom status"""
+        # Create server with custom config
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0003,  # Power Sleep
+                    "available_statuses": {
+                        0x0003: {
+                            "name": "Power Sleep",
+                            "description": "ECU is in sleep mode",
+                        }
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+        response = server.create_power_mode_response()
+
+        # Verify power mode status (should be 0x0003 - Power Sleep)
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x0003
+
+    def test_create_power_mode_response_cycling_enabled(self):
+        """Test power mode response creation with cycling enabled"""
+        # Create server with cycling enabled
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0001,
+                    "available_statuses": {
+                        0x0001: {
+                            "name": "Power On",
+                            "description": "ECU is powered on",
+                        },
+                        0x0002: {
+                            "name": "Power Standby",
+                            "description": "ECU is in standby",
+                        },
+                        0x0003: {
+                            "name": "Power Sleep",
+                            "description": "ECU is in sleep",
+                        },
+                    },
+                    "response_cycling": {
+                        "enabled": True,
+                        "cycle_through": [0x0001, 0x0002, 0x0003],
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+
+        # Test multiple calls to see cycling
+        responses = []
+        for i in range(6):  # Test 2 full cycles
+            response = server.create_power_mode_response()
+            power_status = struct.unpack(">H", response[8:10])[0]
+            responses.append(power_status)
+
+        # Verify cycling pattern: 0x0001, 0x0002, 0x0003, 0x0001, 0x0002, 0x0003
+        expected_pattern = [0x0001, 0x0002, 0x0003, 0x0001, 0x0002, 0x0003]
+        assert responses == expected_pattern
+
+    def test_create_power_mode_response_cycling_empty_list(self):
+        """Test power mode response creation with empty cycling list"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0001,
+                    "response_cycling": {
+                        "enabled": True,
+                        "cycle_through": [],  # Empty list
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+        response = server.create_power_mode_response()
+
+        # Should fall back to current_status when cycling list is empty
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x0001
+
+    def test_create_power_mode_response_missing_config(self):
+        """Test power mode response creation when config is missing"""
+        # Create server with missing power mode config
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                # No power_mode_status section
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+        response = server.create_power_mode_response()
+
+        # Should use default status (0x0001) when config is missing
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x0001
+
+
+class TestPowerModeRequestHandling:
+    """Test power mode request handling functionality"""
+
+    def test_handle_power_mode_request(self):
+        """Test power mode request handling"""
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+
+        # Mock the create_power_mode_response method to verify it's called
+        with patch.object(server, "create_power_mode_response") as mock_create:
+            mock_create.return_value = b"mock_response"
+
+            # Call handle_power_mode_request
+            result = server.handle_power_mode_request(b"")
+
+            # Verify the method was called and result returned
+            mock_create.assert_called_once()
+            assert result == b"mock_response"
+
+    def test_handle_power_mode_request_with_payload(self):
+        """Test power mode request handling with payload (should be ignored)"""
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+
+        # Power mode requests don't use the payload, but we should test it doesn't break
+        with patch.object(server, "create_power_mode_response") as mock_create:
+            mock_create.return_value = b"mock_response"
+
+            # Call with some payload data
+            result = server.handle_power_mode_request(b"some_payload_data")
+
+            # Verify the method was called and result returned
+            mock_create.assert_called_once()
+            assert result == b"mock_response"
+
+
+class TestPowerModeIntegration:
+    """Integration tests for power mode functionality"""
+
+    def test_power_mode_tcp_message_handling(self):
+        """Test power mode request handling through TCP message processing"""
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+
+        # Create a power mode request (payload type 0x0008)
+        power_mode_request = struct.pack(">BBHI", 0x02, 0xFD, 0x0008, 0)  # No payload
+
+        # Process the DoIP message
+        result = server.process_doip_message(power_mode_request)
+
+        # Verify the response is a power mode response
+        assert result is not None
+        assert len(result) == 10  # 8 bytes header + 2 bytes payload
+        assert result[0] == 0x02  # Protocol version
+        assert result[1] == 0xFD  # Inverse protocol version
+        assert struct.unpack(">H", result[2:4])[0] == 0x0008  # Payload type
+        assert struct.unpack(">I", result[4:8])[0] == 2  # Payload length
+
+    def test_power_mode_response_cycling_state_management(self):
+        """Test power mode response cycling state management"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0001,
+                    "response_cycling": {
+                        "enabled": True,
+                        "cycle_through": [0x0001, 0x0002, 0x0003],
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+
+        # Verify initial cycling state is empty
+        cycling_state = server.get_response_cycling_state()
+        assert "power_mode_power_mode_status" not in cycling_state
+
+        # Make first call
+        server.create_power_mode_response()
+        cycling_state = server.get_response_cycling_state()
+        assert cycling_state["power_mode_power_mode_status"] == 1
+
+        # Make second call
+        server.create_power_mode_response()
+        cycling_state = server.get_response_cycling_state()
+        assert cycling_state["power_mode_power_mode_status"] == 2
+
+        # Make third call (should cycle back to 0)
+        server.create_power_mode_response()
+        cycling_state = server.get_response_cycling_state()
+        assert cycling_state["power_mode_power_mode_status"] == 0
+
+    def test_power_mode_logging(self):
+        """Test power mode response logging"""
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+
+        # Capture log output
+        with patch.object(server.logger, "info") as mock_log:
+            server.create_power_mode_response()
+
+            # Verify logging was called
+            mock_log.assert_called()
+            log_calls = [call[0][0] for call in mock_log.call_args_list]
+
+            # Should log the power mode response
+            power_mode_logs = [
+                log for log in log_calls if "Power mode response:" in log
+            ]
+            assert len(power_mode_logs) == 1
+            assert "Power On (0x0001)" in power_mode_logs[0]
+
+    def test_power_mode_response_cycling_logging(self):
+        """Test power mode response cycling logging"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0001,
+                    "response_cycling": {
+                        "enabled": True,
+                        "cycle_through": [0x0001, 0x0002],
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+
+        # Capture log output
+        with patch.object(server.logger, "info") as mock_log:
+            server.create_power_mode_response()
+
+            # Verify cycling logging was called
+            log_calls = [call[0][0] for call in mock_log.call_args_list]
+            cycling_logs = [
+                log for log in log_calls if "Power mode response cycling:" in log
+            ]
+            assert len(cycling_logs) == 1
+            assert "0x0001" in cycling_logs[0]
+
+
+class TestPowerModeEdgeCases:
+    """Test edge cases and error conditions for power mode functionality"""
+
+    def test_power_mode_response_with_invalid_status(self):
+        """Test power mode response with invalid status value"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x9999,  # Invalid status
+                    "available_statuses": {
+                        0x0001: {"name": "Power On", "description": "ECU is powered on"}
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+        response = server.create_power_mode_response()
+
+        # Should still work with invalid status
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x9999
+
+    def test_power_mode_response_cycling_with_single_status(self):
+        """Test power mode response cycling with only one status"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    "current_status": 0x0001,
+                    "response_cycling": {
+                        "enabled": True,
+                        "cycle_through": [0x0001],  # Only one status
+                    },
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+
+        # Test multiple calls - should always return the same status
+        for i in range(5):
+            response = server.create_power_mode_response()
+            power_status = struct.unpack(">H", response[8:10])[0]
+            assert power_status == 0x0001
+
+    def test_power_mode_response_malformed_config(self):
+        """Test power mode response with malformed configuration"""
+        custom_config = {
+            "gateway": {
+                "name": "Test Gateway",
+                "logical_address": 0x1000,
+                "power_mode_status": {
+                    # Missing current_status
+                    "available_statuses": {},
+                    "response_cycling": {"enabled": True, "cycle_through": [0x0001]},
+                },
+            }
+        }
+
+        server = DoIPServer()
+        server.config_manager.gateway_config = custom_config
+        response = server.create_power_mode_response()
+
+        # Should fall back to default status (0x0001)
+        power_status = struct.unpack(">H", response[8:10])[0]
+        assert power_status == 0x0001
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:
- [ x ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements DoIP power mode (0x0008) response sourced from config with optional cycling, adds config schema and tests.
> 
> - **Backend**:
>   - **Power Mode Response**: `create_power_mode_response` now reads `power_mode_status` from config, supports optional response cycling, packs 2-byte status, and logs status/cycling details.
>   - **Cycling State**: `get_response_cycling_state` handles non-integer keys for non-ECU cycles (e.g., power mode).
> - **Config**:
>   - **Gateway YAML**: Adds `gateway.power_mode_status` with `current_status`, `available_statuses`, and `response_cycling` (with `cycle_through`).
>   - **Config Manager**: Adds `get_power_mode_config` to access power mode settings.
> - **Tests**:
>   - Adds `tests/test_power_mode.py` covering config loading/fallback, response generation (default/custom/cycling), TCP handling, cycling state management, logging, and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2cc88bdef347b7534d2b4e836dfedb5b1fb1d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->