### PR TITLE
fix(ci): gate PyPI publish on CI success + add workflow test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,34 @@
 name: Publish to PyPI
 
-# Runs on every merge to main after all CI checks pass.
+# Triggered when the CI workflow completes on main.
+# Only publishes if CI succeeded on a push event — never on a failed or
+# manually-triggered run. Checks out the exact SHA CI validated so the
+# published artifact matches what was tested.
 # Requires the PYPI_TOKEN repository secret to be set.
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+
     permissions:
       contents: write  # needed to push the version tag
 
     steps:
-    - name: Checkout (full history for commit count)
+    - name: Checkout CI-validated commit (full history for commit count)
       uses: actions/checkout@v6
       with:
+        ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _workflow_on(workflow: dict) -> dict:
+    # PyYAML follows YAML 1.1 and parses the GitHub Actions key "on" as True.
+    return workflow.get("on") or workflow[True]
+
+
+def test_publish_waits_for_successful_main_ci_before_publishing():
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text()
+    )
+
+    triggers = _workflow_on(workflow)
+    assert "push" not in triggers
+    assert triggers["workflow_run"] == {
+        "workflows": ["CI"],
+        "types": ["completed"],
+        "branches": ["main"],
+    }
+
+    publish_job = workflow["jobs"]["publish"]
+    job_condition = " ".join(publish_job["if"].split())
+    assert "github.event.workflow_run.conclusion == 'success'" in job_condition
+    assert "github.event.workflow_run.event == 'push'" in job_condition
+    assert "github.event.workflow_run.head_branch == 'main'" in job_condition
+
+    checkout_step = next(
+        step for step in publish_job["steps"] if step["name"].startswith("Checkout")
+    )
+    assert checkout_step["with"]["ref"] == "${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## Summary

Fixes the root cause of the test failure seen in PR #99.

- **`publish.yml`**: Switch trigger from `push` to `workflow_run` so the package is only published after the CI workflow completes successfully on `main`. Also pins the checkout to `github.event.workflow_run.head_sha` — the exact commit CI validated — so the published artifact always matches what was tested.
- **`tests/test_publish_workflow.py`**: Add regression test that asserts the workflow uses `workflow_run` trigger, the correct `if`-condition guards, and the CI-validated SHA checkout. Resolves the failing test from PR #99.

## What changes

| File | Change |
|---|---|
| `.github/workflows/publish.yml` | `push` → `workflow_run`, add `if` guard, pin checkout `ref` |
| `tests/test_publish_workflow.py` | New test — asserts all three invariants above |

## Closes / supersedes

Supersedes PR #99 (that PR only added the test without the matching fix; this PR ships both together).

## Test plan

- `poetry run pytest tests/test_publish_workflow.py -v` → 1 passed ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01LadoGJiaNkGMHuHYb67dq6)_