### PR TITLE
fix: add regression tests for functional diagnostics service filtering

### DIFF
--- a/src/doip_server/doip_server.py
+++ b/src/doip_server/doip_server.py
@@ -5,6 +5,7 @@ DoIP Server implementation for automotive diagnostics.
 This module provides the main DoIP (Diagnostics over IP) server functionality
 for handling automotive diagnostic communication protocols.
 """
+
 import logging
 import socket
 import struct

--- a/tests/test_functional_diagnostics.py
+++ b/tests/test_functional_diagnostics.py
@@ -5,6 +5,7 @@ Tests the ability to send requests to functional addresses and receive responses
 """
 
 import os
+import struct
 import sys
 import unittest
 from unittest.mock import Mock
@@ -13,6 +14,7 @@ from unittest.mock import Mock
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from doip_client.doip_client import DoIPClientWrapper
+from doip_server.doip_server import DoIPServer
 from doip_server.hierarchical_config_manager import HierarchicalConfigManager
 
 
@@ -242,6 +244,70 @@ class TestFunctionalDiagnosticsIntegration(unittest.TestCase):
             self.fail(f"Functional demo raised an exception: {e}")
         finally:
             client.disconnect()
+
+
+class TestFunctionalDiagnosticsTCPDispatch(unittest.TestCase):
+    """Regression tests: functional diagnostics must respect supports_functional flag."""
+
+    # Functional address used by all ECUs in gateway1.yaml config
+    FUNCTIONAL_ADDRESS = 0x0000
+    SOURCE_ADDRESS = 0x0E00
+
+    @staticmethod
+    def _make_doip_message(payload_type, payload):
+        header = struct.pack(">BBHI", 0x02, 0xFD, payload_type, len(payload))
+        return header + payload
+
+    def _make_diagnostic_request(self, source_address, target_address, uds_payload):
+        diag_payload = struct.pack(">HH", source_address, target_address) + uds_payload
+        return self._make_doip_message(0x8001, diag_payload)
+
+    def test_functional_request_returns_ack_and_ecu_responses(self):
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+        # 0x1902: Read DTC — supports_functional=True on all ECUs
+        uds_payload = bytes.fromhex("1902")
+
+        request = self._make_diagnostic_request(
+            self.SOURCE_ADDRESS, self.FUNCTIONAL_ADDRESS, uds_payload
+        )
+        responses = server.process_doip_message(request)
+
+        self.assertIsNotNone(responses)
+        self.assertGreater(len(responses), 0)
+
+        payload_types = [struct.unpack(">H", r[2:4])[0] for r in responses]
+        self.assertEqual(payload_types[0], 0x8002)  # ACK first
+        self.assertNotIn(0x8000, payload_types)  # no NACK
+
+        expected_ecus = set(
+            server.config_manager.get_ecus_by_functional_address(
+                self.FUNCTIONAL_ADDRESS
+            )
+        )
+        response_ecus = {
+            struct.unpack(">H", r[8:10])[0]
+            for r in responses
+            if struct.unpack(">H", r[2:4])[0] == 0x8001
+        }
+        self.assertEqual(response_ecus, expected_ecus)
+        self.assertGreater(len(response_ecus), 0)
+
+    def test_functional_request_rejects_physical_only_service(self):
+        server = DoIPServer(gateway_config_path="config/gateway1.yaml")
+        # 0x31010001: Engine Start/Stop — supports_functional=False (engine ECU only)
+        uds_payload = bytes.fromhex("31010001")
+
+        request = self._make_diagnostic_request(
+            self.SOURCE_ADDRESS, self.FUNCTIONAL_ADDRESS, uds_payload
+        )
+        responses = server.process_doip_message(request)
+
+        self.assertIsNotNone(responses)
+        self.assertEqual(len(responses), 1)
+        payload_types = [struct.unpack(">H", r[2:4])[0] for r in responses]
+        # DoIPServer uses generic NACK (0x8000); nack code 0x04 = no functional responders
+        self.assertEqual(payload_types, [0x8000])
+        self.assertEqual(struct.unpack(">I", responses[0][8:12])[0], 0x04)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ports the regression coverage from PR #105 to main's architecture. Adds TestFunctionalDiagnosticsTCPDispatch with two tests that verify:
- functional requests return ACK + per-ECU responses when supports_functional=True
- physical-only services return NACK when sent to a functional address

Also fixes a Black formatting violation in doip_server.py that would have blocked CI.

https://claude.ai/code/session_01NANpU2X9efj4oy1SJ6J8pU

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
