### PR TITLE
feat: add IPv6 dual-stack support for DoIP server and web layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+poetry install
+
+# Run server with hierarchical config (standard)
+poetry run python src/doip_server/main.py --gateway-config config/gateway1.yaml
+# or via Makefile
+make run-hierarchical
+
+# Run all tests
+poetry run pytest tests/ -v
+
+# Run a single test file
+poetry run pytest tests/test_doip_unit.py -v
+
+# Run a single test by name
+poetry run pytest tests/test_doip_unit.py -v -k "test_name"
+
+# Lint (errors only, then style warnings)
+poetry run flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+poetry run flake8 src/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# Format check / format
+poetry run black --check --diff src/ tests/
+poetry run black src/ tests/
+
+# Security scans
+poetry run bandit -r src/ -f json -o reports/bandit-report.json
+poetry run safety check --json > reports/safety-report.json
+
+# Validate configuration
+poetry run python -c "from src.doip_server.hierarchical_config_manager import HierarchicalConfigManager; HierarchicalConfigManager('config/gateway1.yaml')"
+
+# Build package
+poetry build
+
+# Full CI simulation
+make ci-local
+```
+
+## Architecture
+
+### Package layout
+
+```
+src/
+  doip_server/     # Server package (published to PyPI as doip-server)
+    main.py                    # CLI entry point (--host, --port, --gateway-config)
+    doip_server.py             # DoIPServer class — core TCP+UDP server
+    net_utils.py               # IPv4/IPv6 bind helpers (dual-stack via IPV6_V6ONLY=0)
+    hierarchical_config_manager.py  # YAML config loader/validator
+  doip_client/     # Client package (bundled for testing/demo)
+    doip_client.py             # DoIPClientWrapper around the doipclient library
+    udp_doip_client.py         # Raw UDP client for vehicle identification
+    debug_client.py            # Debug/diagnostic CLI client
+config/
+  gateway1.yaml              # Root config (network, ECU file references)
+  gateway1_ipv6.yaml         # Example dual-stack config (host: "::")
+  ecus/<ecu>/ecu_*.yaml      # Per-ECU config (addresses, service references)
+  generic/generic_uds_messages.yaml  # Common UDS service definitions
+tests/                         # pytest suite; conftest.py sets sys.path and fixtures
+```
+
+### Request flow
+
+`DoIPServer` runs a single-threaded event loop polling both TCP (`server_socket`) and UDP (`udp_socket`) with short timeouts (100 ms each).
+
+- **UDP**: Vehicle identification (0x0001), entity status (0x4001), power mode (0x4003) — all handled in `handle_udp_message`, responded to via `sendto`.
+- **TCP**: Routing activation (0x0005) → `handle_routing_activation`; Diagnostic messages (0x8001) → `handle_diagnostic_message` → `process_uds_message`.
+
+Every TCP diagnostic message returns a **list** of frames: `[ACK_frame, UDS_response_frame, ...]`. Per-response delays (in ms) are applied in `handle_client` before each send.
+
+### IPv6 / dual-stack networking
+
+- `gateway.network.host`: `0.0.0.0` (IPv4 default), `::` (dual-stack when `dual_stack` is true or omitted), or `::1` (IPv6 loopback).
+- `DoIPServer.start()` uses `net_utils.create_listening_socket()` for TCP and UDP.
+- Web dashboard DoIP client proxy (`web/api/doip_client.py`) only allows loopback targets; use `localhost`, `127.0.0.1`, or `::1`.
+
+### Configuration hierarchy
+
+`HierarchicalConfigManager` loads configs in this order:
+1. **`gateway1.yaml`** — network/protocol settings, vehicle info, list of ECU config file paths under `gateway.ecus`.
+2. **Per-ECU YAML** (`ecus/<name>/ecu_<name>.yaml`) — ECU `target_address`, `functional_address` (default `0x1FFF`), `tester_addresses`, and references to UDS service files.
+3. **UDS service files** — keyed by service name; each entry has `request` (hex string), `responses` (list of hex strings or `{response, delay_ms}` dicts), optional `no_response: true`, `supports_functional: true`.
+
+`DoIPServer` asks the manager for everything via its API (`get_uds_service_by_request`, `is_source_address_allowed`, `get_ecus_by_functional_address`, etc.) rather than reading YAML directly.
+
+### Functional vs. physical addressing
+
+- **Physical** (`target_address` = specific ECU address): routed to one ECU.
+- **Functional** (`target_address` = `functional_address`, e.g. `0x1FFF`): `handle_functional_diagnostic_message` iterates all ECUs sharing that functional address and responds from each ECU that has `supports_functional: true` on the matching service.
+
+### Response cycling
+
+`DoIPServer.response_cycle_state` is a `dict` keyed by `(ecu_address, service_name)`. Each UDS hit advances the index, cycling through the `responses` list. Power-mode cycling uses key `("power_mode", "power_mode_status")`.
+
+### Test markers
+
+`pyproject.toml` defines `unit`, `integration`, and `slow` markers. The default `addopts` adds `-v --tb=short --strict-markers --disable-warnings`. `conftest.py` inserts `src/` into `sys.path` at session scope.

--- a/config/gateway1_ipv6.yaml
+++ b/config/gateway1_ipv6.yaml
@@ -1,40 +1,35 @@
-# Gateway Configuration - TCP/IP Network Settings
-# This file contains the network configuration for a DoIP gateway
+# Gateway Configuration - Dual-stack IPv6/IPv4 (example)
+# Binds on :: with IPV6_V6ONLY=0 so IPv4-mapped clients can connect on the same port.
 
 gateway:
   name: "Gateway1"
-  description: "Primary DoIP Gateway"
-  logical_address: 0x1000  # Gateway logical address (DoIP server address)
+  description: "Primary DoIP Gateway (dual-stack)"
+  logical_address: 0x1000
 
-  # Vehicle Information
   vehicle:
-    vin: "1HGBH41JXMN109186"  # Vehicle Identification Number
-    eid: "123456789ABC"  # Entity ID (6 bytes hex)
-    gid: "DEF012345678"  # Group ID (6 bytes hex)
+    vin: "1HGBH41JXMN109186"
+    eid: "123456789ABC"
+    gid: "DEF012345678"
 
-  # TCP/IP Network Configuration
   network:
-    host: "0.0.0.0"  # Listen on all interfaces (IPv4). Use "::" for dual-stack IPv6/IPv4
-    dual_stack: false  # Auto-true when host is "::"; see config/gateway1_ipv6.yaml
+    host: "::"
+    dual_stack: true
     port: 13400
     max_connections: 10
     timeout: 60
     keep_alive: true
     tcp_nodelay: true
 
-  # Protocol Configuration
   protocol:
     version: 0x02
     inverse_version: 0xFD
 
-  # Gateway-specific settings
   settings:
     enable_logging: true
     log_level: "INFO"
     enable_security: false
     allow_multiple_sessions: true
 
-  # ECU References - List of ECU configuration files
   ecus:
     - "ecus/engine/ecu_engine.yaml"
     - "ecus/transmission/ecu_transmission.yaml"
@@ -45,14 +40,12 @@ gateway:
     - "ecus/gateway/ecu_gateway.yaml"
     - "ecus/hvac/ecu_hvac.yaml"
 
-  # Response Codes Configuration
   response_codes:
     routine_activation:
       0x10: "Routine started successfully"
       0x22: "Conditions not correct"
       0x31: "Incorrect routine identifier"
       0x33: "Security access denied"
-
     uds:
       0x10: "General reject"
       0x12: "Sub-function not supported"
@@ -72,10 +65,9 @@ gateway:
       0x7E: "Sub-function not supported in active session"
       0x7F: "Service not supported in active session"
 
-  # Power Mode Status Configuration
   power_mode_status:
     description: "Power mode status values for DoIP power mode response (payload type 0x4004)"
-    current_status: 0x01  # Current power mode status (1 byte)
+    current_status: 0x01
     available_statuses:
       0x00:
         name: "Power Off"
@@ -93,18 +85,16 @@ gateway:
         name: "Power Wake"
         description: "ECU is waking up"
     response_cycling:
-      enabled: false  # Enable cycling through different power mode statuses
-      cycle_through: [0x01, 0x02, 0x03]  # Statuses to cycle through
+      enabled: false
+      cycle_through: [0x01, 0x02, 0x03]
 
-  # DoIP Entity Status Configuration
   entity_status:
     description: "DoIP Entity Status Response configuration (payload type 0x4002)"
-    node_type: 0x01  # Node type: 0x01 = Vehicle Gateway, 0x02 = Node
-    max_open_sockets: 10  # Maximum number of concurrent diagnostic connections
-    current_open_sockets: 0  # Current number of active diagnostic connections
-    doip_entity_status: 0x00  # Entity status: 0x00 = Ready, 0x01 = Not ready
-    diagnostic_power_mode: 0x02  # Diagnostic power mode: 0x01 = Power on, 0x02 = Power off, 0x03 = Not ready
-    # Available node types
+    node_type: 0x01
+    max_open_sockets: 10
+    current_open_sockets: 0
+    doip_entity_status: 0x00
+    diagnostic_power_mode: 0x02
     available_node_types:
       0x01:
         name: "Vehicle Gateway"
@@ -112,7 +102,6 @@ gateway:
       0x02:
         name: "Node"
         description: "DoIP entity is a node"
-    # Available entity statuses
     available_entity_statuses:
       0x00:
         name: "Ready"
@@ -120,7 +109,6 @@ gateway:
       0x01:
         name: "Not Ready"
         description: "Entity is not ready for diagnostic communication"
-    # Available diagnostic power modes
     available_diagnostic_power_modes:
       0x01:
         name: "Power On"
@@ -132,16 +120,14 @@ gateway:
         name: "Not Ready"
         description: "Diagnostic power is not ready"
 
-# Logging Configuration
 logging:
-  level: "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+  level: "INFO"
   format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
   file: "doip_server.log"
   console: true
   max_file_size: "10MB"
   backup_count: 5
 
-# Security Configuration
 security:
   enabled: false
   allowed_sources_strict: false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,7 +22,8 @@ gateway:
   logical_address: 0x1000
 
   network:
-    host: "0.0.0.0"
+    host: "0.0.0.0"       # IPv4 all interfaces (default)
+    dual_stack: false     # Set true with host "::" for IPv4+IPv6 on one socket
     port: 13400
     max_connections: 10
     timeout: 60
@@ -312,6 +313,36 @@ poetry run python -c "from src.doip_server.hierarchical_config_manager import Hi
 # Validate specific configuration
 poetry run python -c "from src.doip_server.hierarchical_config_manager import HierarchicalConfigManager; HierarchicalConfigManager('config/gateway1.yaml').validate_configs()"
 ```
+
+## IPv6 and dual-stack binding
+
+The DoIP server selects the socket family from `gateway.network.host`:
+
+| `host` value | Behavior |
+|---|---|
+| `0.0.0.0` or IPv4 literal | IPv4 only (`AF_INET`) |
+| `::` | IPv6 socket with `IPV6_V6ONLY=0` — accepts IPv4-mapped and native IPv6 clients |
+| `::1` or other IPv6 literal | IPv6 only on that address |
+
+`dual_stack` controls IPv4-mapped access when binding on `::`:
+
+- Omitted with `host: "::"` → dual-stack enabled (default for `::`)
+- `dual_stack: false` with `host: "::"` → IPv6-only wildcard
+- `dual_stack: true` with IPv4 hosts → validation error at startup
+
+Example dual-stack gateway (see also `config/gateway1_ipv6.yaml`):
+
+```yaml
+gateway:
+  network:
+    host: "::"
+    dual_stack: true
+    port: 13400
+```
+
+CLI override: `poetry run python -m doip_server.main --host :: --gateway-config config/gateway1_ipv6.yaml`
+
+**UDP discovery:** IPv4 broadcast (`255.255.255.255`) is unchanged. For IPv6, use unicast to the gateway address or link-local multicast `ff02::1` with `UDPDoIPClient(server_host="ff02::1")`.
 
 ## Configuration Examples
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,6 +56,19 @@ gateway:
     console: false
 ```
 
+#### Production (dual-stack IPv6/IPv4)
+```yaml
+# config/production_ipv6.yaml
+gateway:
+  name: "DoIP Gateway - Production"
+  network:
+    host: "::"
+    dual_stack: true
+    port: 13400
+```
+
+On Linux, ensure the host has IPv6 enabled and firewall rules allow TCP/UDP port 13400 for both `iptables` and `ip6tables`. macOS dual-stack uses `IPV6_V6ONLY=0` automatically when `host` is `::` in the server config.
+
 ### Configuration Validation
 ```bash
 # Validate configuration before deployment

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -36,11 +36,13 @@ poetry run python -m web.app \
 | Flag | Default | Description |
 |---|---|---|
 | `--gateway-config` | `config/gateway1.yaml` | Path to the gateway YAML config |
-| `--host` | `0.0.0.0` | Interface to bind the HTTP server |
+| `--host` | `0.0.0.0` | Interface to bind the HTTP server (`::` for all IPv6 interfaces) |
 | `--port` | `8080` | TCP port for the web dashboard |
 | `--reload` | _(off)_ | Enable uvicorn auto-reload (development only) |
 
-Once running, open `http://localhost:8080` in a browser.
+Once running, open `http://localhost:8080` in a browser. For IPv6 loopback use `http://[::1]:8080`.
+
+Combined DoIP + web mode: `poetry run python -m doip_server.main --web --web-host :: --web-port 8080 --gateway-config config/gateway1_ipv6.yaml`
 
 ---
 
@@ -95,7 +97,7 @@ Fill in:
 
 | Field | Example | Notes |
 |---|---|---|
-| Server host | `127.0.0.1` | Hostname of the DoIP server |
+| Server host | `localhost` | DoIP server host (`127.0.0.1`, `::1`, or `localhost`) |
 | Server port | `13400` | TCP port |
 | Source address | `0x0E00` | Logical address of the tester |
 | Target address | `0x1000` | ECU target address |

--- a/src/doip_client/udp_doip_client.py
+++ b/src/doip_client/udp_doip_client.py
@@ -10,6 +10,11 @@ import struct
 import time
 from typing import Optional
 
+from doip_server.net_utils import (
+    is_ipv6_multicast_host,
+    resolve_client_socket_family,
+)
+
 
 class UDPDoIPClient:
     """
@@ -320,12 +325,17 @@ class UDPDoIPClient:
             bool: True if successful, False otherwise
         """
         try:
-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            family = resolve_client_socket_family(self.server_host)
+            self.socket = socket.socket(family, socket.SOCK_DGRAM)
 
-            # Only enable broadcast if using broadcast address
+            # IPv4 broadcast discovery
             if self.server_host == "255.255.255.255":
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 self.logger.info("UDP client configured for broadcast mode")
+            elif is_ipv6_multicast_host(self.server_host):
+                self.logger.info(
+                    f"UDP client configured for IPv6 multicast to {self.server_host}"
+                )
             else:
                 self.logger.info(
                     f"UDP client configured for unicast mode to {self.server_host}"
@@ -333,8 +343,9 @@ class UDPDoIPClient:
 
             self.socket.settimeout(self.timeout)
 
-            # Bind to any available port
-            self.socket.bind(("", 0))
+            # Bind to any available port (IPv4 or IPv6)
+            bind_addr = "::" if family == socket.AF_INET6 else ""
+            self.socket.bind((bind_addr, 0))
             local_port = self.socket.getsockname()[1]
 
             self.logger.info(f"UDP DoIP client started on port {local_port}")

--- a/src/doip_server/doip_server.py
+++ b/src/doip_server/doip_server.py
@@ -11,6 +11,11 @@ import struct
 import time
 
 from .hierarchical_config_manager import HierarchicalConfigManager
+from .net_utils import (
+    create_listening_socket,
+    format_listen_address,
+    resolve_bind_params,
+)
 
 # DoIP Protocol constants
 DOIP_PROTOCOL_VERSION = 0x02
@@ -122,6 +127,7 @@ class DoIPServer:
         network_config = self.config_manager.get_network_config()
         self.max_connections = network_config.get("max_connections", 5)
         self.timeout = network_config.get("timeout", 30)
+        self.dual_stack = self.config_manager.get_dual_stack(self.host)
 
         # Get protocol configuration
         protocol_config = self.config_manager.get_protocol_config()
@@ -152,10 +158,12 @@ class DoIPServer:
 
     def _validate_binding_config(self):
         """Validate host and port configuration"""
-        # Validate host
-        if not self.host or self.host.strip() == "":
-            self.logger.error("Invalid host configuration: host cannot be empty")
-            raise ValueError("Invalid host configuration: host cannot be empty")
+        # Validate host (IP literal or wildcard)
+        try:
+            resolve_bind_params(self.host, self.dual_stack)
+        except ValueError as exc:
+            self.logger.error(f"Invalid host configuration: {exc}")
+            raise
 
         # Validate port
         if not isinstance(self.port, int) or self.port < 1 or self.port > 65535:
@@ -272,22 +280,25 @@ class DoIPServer:
             OSError: If socket binding fails (e.g., port already in use)
             Exception: If server startup fails for any other reason
         """
-        # Start TCP server
-        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind((self.host, self.port))
-        self.server_socket.listen(self.max_connections)
-
-        # Start UDP server for vehicle identification
-        self.udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.udp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.udp_socket.bind((self.host, self.port))
+        # Start TCP and UDP servers (IPv4, IPv6, or dual-stack per config)
+        self.server_socket = create_listening_socket(
+            socket.SOCK_STREAM,
+            self.host,
+            self.port,
+            dual_stack=self.dual_stack,
+            max_connections=self.max_connections,
+        )
+        self.udp_socket = create_listening_socket(
+            socket.SOCK_DGRAM,
+            self.host,
+            self.port,
+            dual_stack=self.dual_stack,
+        )
 
         self.running = True
 
-        self.logger.info(
-            f"DoIP server listening on {self.host}:{self.port} (TCP and UDP)"
-        )
+        listen_addr = format_listen_address(self.host, self.port, self.dual_stack)
+        self.logger.info(f"DoIP server listening on {listen_addr} (TCP and UDP)")
         self.logger.info(self.config_manager.get_config_summary())
 
         # Signal that server is ready for connections

--- a/src/doip_server/hierarchical_config_manager.py
+++ b/src/doip_server/hierarchical_config_manager.py
@@ -451,6 +451,26 @@ gateway:
         port = network_config.get("port", 13400)
         return host, port
 
+    def get_dual_stack(self, host: Optional[str] = None) -> bool:
+        """Whether to enable IPv4-mapped dual-stack when binding on ::.
+
+        Args:
+            host: Bind address to evaluate; defaults to network.host from config.
+
+        Returns:
+            bool: True when network.dual_stack is set or host is "::" and
+            dual_stack is omitted (defaults to True for "::" only).
+        """
+        network_config = self.get_network_config()
+        bind_host = (
+            host
+            if host is not None
+            else network_config.get("host", "0.0.0.0")  # nosec B104
+        )
+        if "dual_stack" in network_config:
+            return bool(network_config["dual_stack"])
+        return str(bind_host).strip() == "::"
+
     def get_protocol_config(self) -> Dict[str, Any]:
         """Get protocol configuration"""
         return self.get_gateway_config().get("protocol", {})
@@ -842,6 +862,16 @@ gateway:
         network = self.get_network_config()
         if "host" not in network or "port" not in network:
             self.logger.error("Missing network configuration")
+            return False
+        try:
+            from .net_utils import resolve_bind_params
+
+            resolve_bind_params(
+                str(network["host"]),
+                self.get_dual_stack(str(network["host"])),
+            )
+        except ValueError as exc:
+            self.logger.error(f"Invalid network.host: {exc}")
             return False
 
         # Validate protocol configuration

--- a/src/doip_server/main.py
+++ b/src/doip_server/main.py
@@ -79,7 +79,7 @@ def main():
         "--web-host",
         type=str,
         default="127.0.0.1",
-        help="Web dashboard host (default: 127.0.0.1)",
+        help="Web dashboard host (default: 127.0.0.1; use :: for all IPv6 interfaces)",
     )
     parser.add_argument(
         "--web-port",

--- a/src/doip_server/net_utils.py
+++ b/src/doip_server/net_utils.py
@@ -1,0 +1,122 @@
+"""Socket helpers for IPv4/IPv6 and dual-stack DoIP server binding."""
+
+import ipaddress
+import socket
+from typing import Optional, Tuple
+
+# IPv6 multicast for vehicle discovery (optional client use)
+IPV6_LINK_LOCAL_MULTICAST = "ff02::1"
+
+
+def validate_bind_host(host: str) -> str:
+    """Validate a bind host string; return normalized host for bind()."""
+    if not host or not str(host).strip():
+        raise ValueError("network.host must not be empty")
+    host = str(host).strip()
+    try:
+        ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise ValueError(f"Invalid network.host: {host!r}") from exc
+    return host
+
+
+def resolve_bind_params(
+    host: str, dual_stack: Optional[bool] = None
+) -> Tuple[int, str, bool]:
+    """Resolve socket family, bind address, and dual-stack flag from host config.
+
+    Args:
+        host: Bind address from configuration (e.g. "0.0.0.0", "::", "::1").
+        dual_stack: Explicit dual-stack override. When None, True only for "::".
+
+    Returns:
+        (address_family, bind_host, enable_dual_stack)
+    """
+    bind_host = validate_bind_host(host)
+    addr = ipaddress.ip_address(bind_host)
+
+    if addr.version == 6:
+        family = socket.AF_INET6
+        if dual_stack is None:
+            enable_dual_stack = bind_host == "::"
+        else:
+            enable_dual_stack = bool(dual_stack)
+        if enable_dual_stack and bind_host != "::":
+            raise ValueError("dual_stack is only supported when network.host is '::'")
+        return family, bind_host, enable_dual_stack
+
+    # IPv4
+    if dual_stack:
+        raise ValueError("dual_stack requires an IPv6 bind host (use host: '::')")
+    return socket.AF_INET, bind_host, False
+
+
+def format_listen_address(host: str, port: int, dual_stack: bool) -> str:
+    """Format host:port for logs (bracket IPv6 literals)."""
+    try:
+        if ipaddress.ip_address(host).version == 6:
+            suffix = ", dual-stack" if dual_stack else ""
+            return f"[{host}]:{port}{suffix}"
+    except ValueError:
+        pass
+    suffix = ", dual-stack" if dual_stack else ""
+    return f"{host}:{port}{suffix}"
+
+
+def resolve_client_socket_family(server_host: str) -> int:
+    """Pick AF_INET or AF_INET6 for a client connecting to server_host."""
+    host = str(server_host).strip()
+    if host in ("255.255.255.255", ""):
+        return socket.AF_INET
+    try:
+        if ipaddress.ip_address(host).version == 6:
+            return socket.AF_INET6
+    except ValueError:
+        pass
+    return socket.AF_INET
+
+
+def is_ipv6_multicast_host(server_host: str) -> bool:
+    """True if server_host is an IPv6 multicast address."""
+    host = str(server_host).strip()
+    try:
+        addr = ipaddress.ip_address(host)
+        return addr.version == 6 and addr.is_multicast
+    except ValueError:
+        return False
+
+
+def create_listening_socket(
+    sock_type: int,
+    host: str,
+    port: int,
+    *,
+    dual_stack: bool = False,
+    max_connections: int = 5,
+) -> socket.socket:
+    """Create a bound listening socket (TCP or UDP) for the given host/port.
+
+    Args:
+        sock_type: socket.SOCK_STREAM or socket.SOCK_DGRAM
+        host: Address to bind (validated via resolve_bind_params)
+        port: Port number
+        dual_stack: When True with IPv6, set IPV6_V6ONLY=0 for IPv4-mapped peers
+        max_connections: listen() backlog for TCP only
+
+    Returns:
+        Bound socket (TCP sockets are already listen()-ing)
+    """
+    family, bind_host, enable_dual_stack = resolve_bind_params(host, dual_stack)
+
+    sock = socket.socket(family, sock_type)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if family == socket.AF_INET6 and enable_dual_stack:
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        sock.bind((bind_host, port))
+        if sock_type == socket.SOCK_STREAM:
+            sock.listen(max_connections)
+    except Exception:
+        sock.close()
+        raise
+    return sock

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -57,7 +57,7 @@ class ServiceUpdate(BaseModel):
 
 
 class DoIPSendRequest(BaseModel):
-    host: str = "127.0.0.1"
+    host: str = "localhost"
     port: int = 13400
     source_address: int = 0x0E00
     target_address: int

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -19,7 +19,10 @@ document.body.addEventListener("htmx:beforeSwap", function (evt) {
   if (id === "status-badge") {
     const color = data.running ? "bg-green-500" : "bg-red-500";
     const label = data.running ? "Running" : "Stopped";
-    const host = data.host && data.port ? ` ${data.host}:${data.port}` : "";
+    const host =
+      data.host && data.port
+        ? ` ${formatHostPort(data.host, data.port)}`
+        : "";
     evt.detail.serverResponse = `
       <div id="status-badge"
            hx-get="/api/status" hx-trigger="every 5s" hx-swap="outerHTML"
@@ -181,6 +184,13 @@ function renderGateway(data) {
 }
 
 // ── Shared UI helpers ─────────────────────────────────────────────────────────
+
+function formatHostPort(host, port) {
+  if (typeof host === "string" && host.includes(":") && !host.startsWith("[")) {
+    return `[${host}]:${port}`;
+  }
+  return `${host}:${port}`;
+}
 
 const INP =
   "bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white w-full";

--- a/src/web/templates/client.html
+++ b/src/web/templates/client.html
@@ -12,7 +12,7 @@
 
     <label class="flex flex-col gap-1 text-xs">
       Host
-      <input x-model="form.host" type="text"
+      <input x-model="form.host" type="text" placeholder="localhost, 127.0.0.1, or ::1"
              class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white"/>
     </label>
     <label class="flex flex-col gap-1 text-xs">
@@ -83,7 +83,7 @@
 function doipClient() {
   return {
     form: {
-      host: '127.0.0.1',
+      host: 'localhost',
       port: 13400,
       source_address: 0x0E00,
       target_address: 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,27 @@ Pytest configuration for DoIP tests.
 Sets up the test environment and provides common fixtures.
 """
 
+import socket
 import sys
 from pathlib import Path
 
 import pytest
+
+
+def _ipv6_loopback_available() -> bool:
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.bind(("::1", 0))
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="session")
+def has_ipv6():
+    """True when the test host can bind to IPv6 loopback."""
+    return _ipv6_loopback_available()
 
 # Add the src directory to the path so we can import the modules
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def has_ipv6():
     """True when the test host can bind to IPv6 loopback."""
     return _ipv6_loopback_available()
 
+
 # Add the src directory to the path so we can import the modules
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 

--- a/tests/test_ipv6_integration.py
+++ b/tests/test_ipv6_integration.py
@@ -1,0 +1,85 @@
+"""IPv6 loopback integration tests (skipped when IPv6 is unavailable)."""
+
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from doip_server.doip_server import DoIPServer
+
+DOIP_VERSION = 0x02
+DOIP_INV_VERSION = 0xFD
+VEHICLE_IDENTIFICATION_REQUEST = 0x0001
+
+
+def _free_ipv6_loopback_port() -> int:
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    sock.bind(("::1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _vehicle_identification_request() -> bytes:
+    return struct.pack(
+        ">BBHI",
+        0xFF,
+        0x00,
+        VEHICLE_IDENTIFICATION_REQUEST,
+        0,
+    )
+
+
+@pytest.mark.integration
+def test_doip_server_binds_ipv6_loopback(has_ipv6):
+    if not has_ipv6:
+        pytest.skip("IPv6 loopback not available")
+
+    port = _free_ipv6_loopback_port()
+    server = DoIPServer(
+        host="::1",
+        port=port,
+        gateway_config_path="config/gateway1.yaml",
+    )
+    assert server.dual_stack is False
+
+    thread = threading.Thread(target=server.start, daemon=True)
+    thread.start()
+
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if server.running:
+            break
+        time.sleep(0.05)
+    assert server.running
+
+    try:
+        tcp = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        tcp.settimeout(2.0)
+        tcp.connect(("::1", port))
+        tcp.close()
+
+        udp = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        udp.settimeout(2.0)
+        udp.sendto(_vehicle_identification_request(), ("::1", port))
+        data, addr = udp.recvfrom(4096)
+        udp.close()
+        assert len(data) >= 8
+        assert addr[0] == "::1"
+    finally:
+        server.stop()
+        thread.join(timeout=3.0)
+
+
+@pytest.mark.integration
+def test_doip_server_dual_stack_config(has_ipv6):
+    if not has_ipv6:
+        pytest.skip("IPv6 loopback not available")
+
+    from doip_server.hierarchical_config_manager import HierarchicalConfigManager
+
+    cm = HierarchicalConfigManager("config/gateway1_ipv6.yaml")
+    assert cm.get_server_binding_info()[0] == "::"
+    assert cm.get_dual_stack("::") is True

--- a/tests/test_net_utils.py
+++ b/tests/test_net_utils.py
@@ -1,0 +1,90 @@
+"""Unit tests for doip_server.net_utils."""
+
+import socket
+
+import pytest
+
+from doip_server.net_utils import (
+    create_listening_socket,
+    format_listen_address,
+    resolve_bind_params,
+    resolve_client_socket_family,
+    validate_bind_host,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host, dual_stack, expected_family, expected_dual",
+    [
+        ("0.0.0.0", None, socket.AF_INET, False),
+        ("127.0.0.1", None, socket.AF_INET, False),
+        ("::", None, socket.AF_INET6, True),
+        ("::1", None, socket.AF_INET6, False),
+        ("::", False, socket.AF_INET6, False),
+        ("::", True, socket.AF_INET6, True),
+    ],
+)
+def test_resolve_bind_params(host, dual_stack, expected_family, expected_dual):
+    family, bind_host, enable_dual = resolve_bind_params(host, dual_stack)
+    assert family == expected_family
+    assert bind_host == host
+    assert enable_dual == expected_dual
+
+
+@pytest.mark.unit
+def test_resolve_bind_params_invalid_host():
+    with pytest.raises(ValueError, match="Invalid network.host"):
+        resolve_bind_params("not-an-ip", None)
+
+
+@pytest.mark.unit
+def test_resolve_bind_params_dual_stack_on_ipv4():
+    with pytest.raises(ValueError, match="dual_stack requires"):
+        resolve_bind_params("0.0.0.0", True)
+
+
+@pytest.mark.unit
+def test_resolve_bind_params_dual_stack_on_non_wildcard_ipv6():
+    with pytest.raises(ValueError, match="only supported when"):
+        resolve_bind_params("::1", True)
+
+
+@pytest.mark.unit
+def test_validate_bind_host_empty():
+    with pytest.raises(ValueError, match="must not be empty"):
+        validate_bind_host("")
+
+
+@pytest.mark.unit
+def test_format_listen_address_ipv6():
+    assert format_listen_address("::1", 13400, False) == "[::1]:13400"
+    assert format_listen_address("::", 13400, True) == "[::]:13400, dual-stack"
+
+
+@pytest.mark.unit
+def test_resolve_client_socket_family():
+    assert resolve_client_socket_family("127.0.0.1") == socket.AF_INET
+    assert resolve_client_socket_family("::1") == socket.AF_INET6
+    assert resolve_client_socket_family("255.255.255.255") == socket.AF_INET
+
+
+@pytest.mark.unit
+def test_create_listening_socket_tcp_ipv4():
+    sock = create_listening_socket(socket.SOCK_STREAM, "127.0.0.1", 0)
+    try:
+        assert sock.family == socket.AF_INET
+        assert sock.getsockname()[0] == "127.0.0.1"
+    finally:
+        sock.close()
+
+
+@pytest.mark.unit
+def test_create_listening_socket_udp_ipv6_loopback(has_ipv6):
+    if not has_ipv6:
+        pytest.skip("IPv6 loopback not available")
+    sock = create_listening_socket(socket.SOCK_DGRAM, "::1", 0)
+    try:
+        assert sock.family == socket.AF_INET6
+    finally:
+        sock.close()

--- a/tests/test_response_delay.py
+++ b/tests/test_response_delay.py
@@ -32,6 +32,7 @@ class TestResponseDelay(unittest.TestCase):
             "max_connections": 5,
             "timeout": 30,
         }
+        self.mock_config_manager.get_dual_stack.return_value = False
         self.mock_config_manager.get_protocol_config.return_value = {
             "version": 0x02,
             "inverse_version": 0xFD,

--- a/tests/test_web/test_api_doip_client.py
+++ b/tests/test_web/test_api_doip_client.py
@@ -3,13 +3,33 @@
 The actual TCP socket call is mocked so these remain fast unit tests.
 """
 
-import json
 from unittest.mock import patch
 
 import pytest
 
+from web.api.doip_client import _resolve_loopback_host
+
 # The sync function we'll mock out
 _TARGET = "web.api.doip_client._send_diagnostic_sync"
+
+
+@pytest.mark.unit
+def test_resolve_loopback_host_ipv6():
+    assert _resolve_loopback_host("::1", 13400) == "::1"
+
+
+@pytest.mark.unit
+def test_resolve_loopback_host_localhost():
+    import ipaddress
+
+    resolved = _resolve_loopback_host("localhost", 13400)
+    assert ipaddress.ip_address(resolved).is_loopback
+
+
+@pytest.mark.unit
+def test_resolve_loopback_host_rejects_public():
+    with pytest.raises(ValueError, match="loopback"):
+        _resolve_loopback_host("8.8.8.8", 13400)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Enable opt-in dual-stack binding on :: via net_utils, extend gateway config with dual_stack and gateway1_ipv6.yaml, update UDP client and web client tester for IPv6 loopback, and add tests plus documentation.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
