### PR TITLE
feat(web): show running git tag/hash in dashboard sidebar

### DIFF
--- a/src/web/api/status.py
+++ b/src/web/api/status.py
@@ -1,15 +1,48 @@
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
 from fastapi import APIRouter
+
+from doip_server import __version__
 from web.state import get_state
 
 router = APIRouter(tags=["status"])
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_git(*args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+@lru_cache(maxsize=1)
+def _git_info() -> dict:
+    """Git tag/hash of the running checkout, cached for the process lifetime."""
+    return {
+        "git_tag": _run_git("describe", "--tags", "--always"),
+        "git_hash": _run_git("rev-parse", "--short", "HEAD"),
+    }
 
 
 @router.get("/api/status")
 def server_status():
     state = get_state()
     cm = state.config_manager
+    info = {"version": __version__, **_git_info()}
     if cm is None:
-        return {"running": False, "ecus": 0, "services": 0}
+        return {"running": False, "ecus": 0, "services": 0, **info}
 
     return {
         "running": state.is_running,
@@ -17,4 +50,5 @@ def server_status():
         "port": cm.get_network_config().get("port"),
         "ecu_count": len(cm.get_all_ecu_addresses()),
         "service_count": len(cm.uds_services),
+        **info,
     }

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -33,6 +33,16 @@ document.body.addEventListener("htmx:beforeSwap", function (evt) {
       </div>`;
   }
 
+  if (id === "version-info") {
+    const tag = data.git_tag || data.version || "unknown";
+    const hash = data.git_hash;
+    const text = hash && !tag.includes(hash) ? `${tag} (${hash})` : tag;
+    evt.detail.serverResponse = `
+      <div id="version-info" class="mt-1 text-[10px] text-gray-600" title="Version ${data.version ?? ""}">
+        ${text}
+      </div>`;
+  }
+
   if (id === "stats-grid") {
     // Swapped with innerHTML into #stats-grid: return ONLY the cards (no wrapper
     // with the same id, which would otherwise nest a grid inside the grid).

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -56,6 +56,11 @@
             <span class="w-2 h-2 rounded-full bg-gray-500"></span> checking…
           </span>
         </div>
+        <div id="version-info"
+             hx-get="/api/status"
+             hx-trigger="load"
+             hx-swap="outerHTML"
+             class="mt-1 text-[10px] text-gray-600"></div>
       </div>
     </nav>
 


### PR DESCRIPTION
## Summary
- `/api/status` now returns `version`, `git_tag` (`git describe --tags --always`), and `git_hash` (`git rev-parse --short HEAD`) for the running checkout, cached for the process lifetime
- Dashboard sidebar renders the git tag/hash under the server status badge (with the package version in a tooltip), so it's clear exactly which build is deployed

## Test plan
- [x] `poetry run pytest tests/test_web -k status -v` passes
- [x] Manually started the web server and confirmed `/api/status` returns `version`, `git_tag`, `git_hash`