### PR TITLE
feat(web): support functional (broadcast) requests in DoIP client UI

### DIFF
--- a/src/web/api/doip_client.py
+++ b/src/web/api/doip_client.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from web.models import DoIPSendRequest
+from web.state import get_state
 
 router = APIRouter(prefix="/api/client", tags=["doip-client"])
 
@@ -19,6 +20,9 @@ ROUTING_ACTIVATION_REQUEST = 0x0005
 DIAGNOSTIC_MESSAGE = 0x8001
 MAX_DOIP_PAYLOAD_LEN = 64 * 1024
 EXPECTED_RESPONSE_TYPES = {0x0006, 0x8001, 0x8002, 0x8003}
+# Extra time to wait for additional responses from other ECUs after a
+# functional (broadcast) request, once the first UDS response is in.
+FUNCTIONAL_EXTRA_TIMEOUT = 0.5
 
 
 def _build_header(payload_type: int, payload_len: int) -> bytes:
@@ -146,24 +150,63 @@ def _send_diagnostic_sync(req: DoIPSendRequest) -> dict:
                 note("got_ack")
             elif ack_frame and ack_frame["type"] == 0x8003:
                 note("got_nack", ack_frame["payload"].hex())
-                return {"ok": False, "log": log, "response": None}
+                return {"ok": False, "log": log, "response": None, "responses": []}
 
-            # UDS response
-            resp_frame = _parse_doip_frame(sock)
-            if resp_frame and resp_frame["type"] == 0x8001:
-                uds_response = resp_frame["payload"][4:].hex().upper()
-                note("got_response", uds_response)
-                return {"ok": True, "log": log, "response": uds_response}
+            # UDS response(s) — a functional (broadcast) request may receive one
+            # response frame per responding ECU.
+            cm = get_state().config_manager
+            is_functional = bool(
+                cm and cm.get_ecus_by_functional_address(req.target_address)
+            )
 
-            note("no_response")
-            return {"ok": False, "log": log, "response": None}
+            responses: list[dict] = []
+            while True:
+                sock.settimeout(
+                    req.timeout if not responses else FUNCTIONAL_EXTRA_TIMEOUT
+                )
+                try:
+                    resp_frame = _parse_doip_frame(sock)
+                except TimeoutError:
+                    break
+
+                if resp_frame is None:
+                    break
+                if resp_frame["type"] != 0x8001:
+                    note("unexpected_frame", f"type=0x{resp_frame['type']:04X}")
+                    break
+
+                payload = resp_frame["payload"]
+                ecu_address = int.from_bytes(payload[0:2], "big")
+                uds_response = payload[4:].hex().upper()
+                note("got_response", f"from 0x{ecu_address:04X}: {uds_response}")
+                responses.append(
+                    {
+                        "ecu_address": ecu_address,
+                        "ecu_address_hex": f"0x{ecu_address:04X}",
+                        "response": uds_response,
+                    }
+                )
+
+                if not is_functional:
+                    break
+
+            if not responses:
+                note("no_response")
+                return {"ok": False, "log": log, "response": None, "responses": []}
+
+            return {
+                "ok": True,
+                "log": log,
+                "response": responses[0]["response"],
+                "responses": responses,
+            }
 
     except TimeoutError:
         note("timeout")
-        return {"ok": False, "log": log, "response": None}
+        return {"ok": False, "log": log, "response": None, "responses": []}
     except Exception as exc:
         note("error", str(exc))
-        return {"ok": False, "log": log, "response": None}
+        return {"ok": False, "log": log, "response": None, "responses": []}
 
 
 @router.post("/send")
@@ -203,6 +246,7 @@ async def doip_client_ws(websocket: WebSocket):
                     "event": "done",
                     "ok": result["ok"],
                     "response": result["response"],
+                    "responses": result.get("responses", []),
                 }
             )
 

--- a/src/web/api/ecus.py
+++ b/src/web/api/ecus.py
@@ -33,6 +33,58 @@ def list_ecus():
     return [_ecu_summary(cm, addr) for addr in cm.get_all_ecu_addresses()]
 
 
+@router.get("/functional-addresses")
+def list_functional_addresses():
+    """Group ECUs by functional address, with the services each group can broadcast."""
+    cm = _require_cm()
+
+    groups: dict[int, list[int]] = {}
+    for addr in cm.get_all_ecu_addresses():
+        func_addr = cm.get_ecu_functional_address(addr)
+        if func_addr is None:
+            continue
+        groups.setdefault(func_addr, []).append(addr)
+
+    result = []
+    for func_addr, ecu_addresses in groups.items():
+        services: dict[str, dict] = {}
+        for ecu_addr in ecu_addresses:
+            ecu_services = cm.get_ecu_uds_services(ecu_addr)
+            for name in cm.get_uds_services_supporting_functional(ecu_addr):
+                entry = services.setdefault(
+                    name,
+                    {
+                        "name": name,
+                        "request": ecu_services[name].get("request"),
+                        "ecus": [],
+                    },
+                )
+                entry["ecus"].append(f"0x{ecu_addr:04X}")
+
+        result.append(
+            {
+                "functional_address": func_addr,
+                "functional_address_hex": f"0x{func_addr:04X}",
+                "ecus": [
+                    {
+                        "target_address": addr,
+                        "target_address_hex": f"0x{addr:04X}",
+                        "name": (cm.get_ecu_config(addr) or {})
+                        .get("ecu", {})
+                        .get("name", "Unknown"),
+                        "tester_addresses": (cm.get_ecu_config(addr) or {})
+                        .get("ecu", {})
+                        .get("tester_addresses", []),
+                    }
+                    for addr in ecu_addresses
+                ],
+                "services": list(services.values()),
+            }
+        )
+
+    return result
+
+
 @router.get("/{address}")
 def get_ecu(address: int):
     cm = _require_cm()

--- a/src/web/templates/client.html
+++ b/src/web/templates/client.html
@@ -45,45 +45,97 @@
     <!-- Named mode: ECU + service pickers -->
     <template x-if="mode === 'named'">
       <div class="space-y-4 border-t border-gray-700 pt-4">
-        <label class="flex flex-col gap-1 text-xs">
-          ECU
-          <select x-model.number="selectedEcuAddress"
-                  @change="onEcuChange()"
-                  class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
-            <option value="">— Select ECU —</option>
-            <template x-for="ecu in ecus" :key="ecu.target_address">
-              <option :value="ecu.target_address"
-                      x-text="`${ecu.name} (${ecu.target_address_hex})`"></option>
-            </template>
-          </select>
+        <label class="flex items-center gap-2 text-xs">
+          <input type="checkbox" x-model="functional" @change="onFunctionalToggle()"/>
+          Send as functional (broadcast)
         </label>
 
-        <label class="flex flex-col gap-1 text-xs">
-          Service
-          <select x-model="selectedServiceName"
-                  @change="onServiceChange()"
-                  @focus="loadServicesIfNeeded()"
-                  :disabled="!selectedEcuAddress"
-                  class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white disabled:opacity-50">
-            <option value="">— Select service —</option>
-            <template x-for="svc in services" :key="svc.name">
-              <option :value="svc.name" x-text="svc.name"></option>
-            </template>
-          </select>
-        </label>
+        <template x-if="!functional">
+          <div class="space-y-4">
+            <label class="flex flex-col gap-1 text-xs">
+              ECU
+              <select x-model.number="selectedEcuAddress"
+                      @change="onEcuChange()"
+                      class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
+                <option value="">— Select ECU —</option>
+                <template x-for="ecu in ecus" :key="ecu.target_address">
+                  <option :value="ecu.target_address"
+                          x-text="`${ecu.name} (${ecu.target_address_hex})`"></option>
+                </template>
+              </select>
+            </label>
 
-        <div class="text-[10px] text-gray-500 space-y-1" x-show="selectedEcuAddress && selectedServiceName">
-          <div>Target: <span class="text-gray-300" x-text="'0x' + form.target_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
-          <div>Source: <span class="text-gray-300" x-text="'0x' + form.source_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
-          <div>UDS: <span class="text-gray-300 font-mono" x-text="form.uds_message"></span></div>
-        </div>
+            <label class="flex flex-col gap-1 text-xs">
+              Service
+              <select x-model="selectedServiceName"
+                      @change="onServiceChange()"
+                      @focus="loadServicesIfNeeded()"
+                      :disabled="!selectedEcuAddress"
+                      class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white disabled:opacity-50">
+                <option value="">— Select service —</option>
+                <template x-for="svc in services" :key="svc.name">
+                  <option :value="svc.name" x-text="svc.name"></option>
+                </template>
+              </select>
+            </label>
 
-        <button type="button"
-                @click="createServiceForEcu()"
-                :disabled="!selectedEcuAddress"
-                class="text-xs px-3 py-1 bg-green-700 hover:bg-green-600 disabled:opacity-50 rounded">
-          + New service for this ECU
-        </button>
+            <div class="text-[10px] text-gray-500 space-y-1" x-show="selectedEcuAddress && selectedServiceName">
+              <div>Target: <span class="text-gray-300" x-text="'0x' + form.target_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
+              <div>Source: <span class="text-gray-300" x-text="'0x' + form.source_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
+              <div>UDS: <span class="text-gray-300 font-mono" x-text="form.uds_message"></span></div>
+            </div>
+
+            <button type="button"
+                    @click="createServiceForEcu()"
+                    :disabled="!selectedEcuAddress"
+                    class="text-xs px-3 py-1 bg-green-700 hover:bg-green-600 disabled:opacity-50 rounded">
+              + New service for this ECU
+            </button>
+          </div>
+        </template>
+
+        <template x-if="functional">
+          <div class="space-y-4">
+            <label class="flex flex-col gap-1 text-xs">
+              Functional group
+              <select x-model.number="selectedFunctionalAddress"
+                      @change="onFunctionalGroupChange()"
+                      class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
+                <option value="">— Select functional address —</option>
+                <template x-for="group in functionalGroups" :key="group.functional_address">
+                  <option :value="group.functional_address"
+                          x-text="`${group.functional_address_hex} (${group.ecus.length} ECUs)`"></option>
+                </template>
+              </select>
+            </label>
+
+            <label class="flex flex-col gap-1 text-xs">
+              Service
+              <select x-model="selectedFunctionalServiceName"
+                      @change="onFunctionalServiceChange()"
+                      :disabled="selectedFunctionalAddress === ''"
+                      class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white disabled:opacity-50">
+                <option value="">— Select service —</option>
+                <template x-for="svc in currentFunctionalServices()" :key="svc.name">
+                  <option :value="svc.name" x-text="svc.name"></option>
+                </template>
+              </select>
+            </label>
+
+            <div class="text-[10px] text-gray-500 space-y-1" x-show="selectedFunctionalAddress !== '' && selectedFunctionalServiceName">
+              <div>Functional target: <span class="text-gray-300" x-text="'0x' + form.target_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
+              <div>Source: <span class="text-gray-300" x-text="'0x' + form.source_address.toString(16).toUpperCase().padStart(4, '0')"></span></div>
+              <div>UDS: <span class="text-gray-300 font-mono" x-text="form.uds_message"></span></div>
+              <div>Broadcasts to:
+                <span class="text-gray-300" x-text="(currentFunctionalGroup()?.ecus || []).map(e => e.name).join(', ')"></span>
+              </div>
+            </div>
+
+            <div class="text-xs text-gray-500" x-show="selectedFunctionalAddress !== '' && currentFunctionalServices().length === 0">
+              No functional-capable services found for this group.
+            </div>
+          </div>
+        </template>
       </div>
     </template>
 
@@ -119,10 +171,19 @@
   <div class="flex flex-col gap-4">
     <div class="bg-gray-800 border border-gray-700 rounded p-4">
       <h2 class="font-bold text-gray-300 mb-2">Response</h2>
-      <div x-show="response !== null"
-           :class="ok ? 'text-green-400' : 'text-red-400'"
-           class="text-base break-all" x-text="response ?? '—'"></div>
-      <div x-show="response === null" class="text-gray-500">—</div>
+      <template x-if="done && responses.length > 0">
+        <div class="space-y-1">
+          <template x-for="(r, i) in responses" :key="i">
+            <div :class="ok ? 'text-green-400' : 'text-red-400'" class="text-base break-all">
+              <span x-show="responses.length > 1 && r.ecu_address_hex"
+                    class="text-gray-500 text-xs mr-1" x-text="r.ecu_address_hex + ':'"></span>
+              <span x-text="r.response"></span>
+            </div>
+          </template>
+        </div>
+      </template>
+      <div x-show="done && responses.length === 0" class="text-red-400 text-base">FAILED — no response</div>
+      <div x-show="!done" class="text-gray-500">—</div>
     </div>
 
     <div class="bg-gray-900 border border-gray-700 rounded p-4 flex-1 overflow-y-auto max-h-96">
@@ -162,8 +223,13 @@ function doipClient() {
     services: [],
     selectedEcuAddress: '',
     selectedServiceName: '',
+    functional: false,
+    functionalGroups: [],
+    selectedFunctionalAddress: '',
+    selectedFunctionalServiceName: '',
     log: [],
-    response: null,
+    responses: [],
+    done: false,
     ok: false,
     busy: false,
     ws: null,
@@ -249,15 +315,65 @@ function doipClient() {
       newService(Number(this.selectedEcuAddress));
     },
 
+    onFunctionalToggle() {
+      this.selectedFunctionalAddress = '';
+      this.selectedFunctionalServiceName = '';
+      if (this.functional && this.functionalGroups.length === 0) {
+        this.loadFunctionalGroups();
+      }
+    },
+
+    async loadFunctionalGroups() {
+      try {
+        const res = await fetch('/api/ecus/functional-addresses');
+        if (!res.ok) throw new Error(res.statusText);
+        this.functionalGroups = await res.json();
+      } catch (e) {
+        console.error('Failed to load functional addresses', e);
+      }
+    },
+
+    currentFunctionalGroup() {
+      return this.functionalGroups.find(g => g.functional_address === Number(this.selectedFunctionalAddress));
+    },
+
+    currentFunctionalServices() {
+      const group = this.currentFunctionalGroup();
+      return group ? group.services : [];
+    },
+
+    onFunctionalGroupChange() {
+      this.selectedFunctionalServiceName = '';
+      const group = this.currentFunctionalGroup();
+      if (!group) return;
+      this.form.target_address = group.functional_address;
+      const firstEcu = group.ecus[0];
+      if (firstEcu && firstEcu.tester_addresses && firstEcu.tester_addresses.length) {
+        this.form.source_address = firstEcu.tester_addresses[0];
+      }
+    },
+
+    onFunctionalServiceChange() {
+      const svc = this.currentFunctionalServices().find(s => s.name === this.selectedFunctionalServiceName);
+      if (!svc) return;
+      let req = svc.request || '';
+      req = String(req).replace(/^0x/i, '').replace(/\s/g, '');
+      this.form.uds_message = req.toUpperCase();
+    },
+
     canSend() {
       if (this.mode === 'named') {
+        if (this.functional) {
+          return this.selectedFunctionalAddress !== '' && this.selectedFunctionalServiceName && this.form.uds_message;
+        }
         return this.selectedEcuAddress && this.selectedServiceName && this.form.uds_message;
       }
       return this.form.target_address != null && this.form.uds_message;
     },
 
     send() {
-      this.response = null;
+      this.responses = [];
+      this.done = false;
       this.busy = true;
 
       if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
@@ -273,7 +389,10 @@ function doipClient() {
     _onMessage(msg) {
       if (msg.event === 'done') {
         this.ok = msg.ok;
-        this.response = msg.response ?? (msg.ok ? '(no data)' : 'FAILED');
+        this.responses = msg.responses && msg.responses.length
+          ? msg.responses
+          : (msg.response ? [{ ecu_address_hex: null, response: msg.response }] : []);
+        this.done = true;
         this.busy = false;
       } else {
         this.log.push(msg);
@@ -282,7 +401,8 @@ function doipClient() {
 
     clearLog() {
       this.log = [];
-      this.response = null;
+      this.responses = [];
+      this.done = false;
     },
   };
 }

--- a/tests/test_web/test_api_doip_client.py
+++ b/tests/test_web/test_api_doip_client.py
@@ -3,11 +3,13 @@
 The actual TCP socket call is mocked so these remain fast unit tests.
 """
 
+import struct
 from unittest.mock import patch
 
 import pytest
 
-from web.api.doip_client import _resolve_loopback_host
+from web.api.doip_client import _resolve_loopback_host, _send_diagnostic_sync
+from web.models import DoIPSendRequest
 
 # The sync function we'll mock out
 _TARGET = "web.api.doip_client._send_diagnostic_sync"
@@ -37,6 +39,13 @@ def test_send_success(web_client):
     mock_result = {
         "ok": True,
         "response": "62F1901HGBH41JXM",
+        "responses": [
+            {
+                "ecu_address": 1,
+                "ecu_address_hex": "0x0001",
+                "response": "62F1901HGBH41JXM",
+            }
+        ],
         "log": [{"ts": 0, "event": "connected", "detail": ""}],
     }
     with patch(_TARGET, return_value=mock_result):
@@ -61,6 +70,7 @@ def test_send_timeout(web_client):
     mock_result = {
         "ok": False,
         "response": None,
+        "responses": [],
         "log": [{"ts": 0, "event": "timeout", "detail": ""}],
     }
     with patch(_TARGET, return_value=mock_result):
@@ -93,11 +103,122 @@ def test_send_invalid_hex(web_client):
     assert r.status_code == 422
 
 
+def _doip_frame(payload_type: int, payload: bytes) -> bytes:
+    return struct.pack(">BBHI", 0x02, 0xFD, payload_type, len(payload)) + payload
+
+
+class _FakeSocket:
+    """Minimal socket stand-in that serves a fixed byte stream then times out."""
+
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+
+    def settimeout(self, timeout):
+        pass
+
+    def sendall(self, data):
+        pass
+
+    def recv(self, n):
+        if self.pos >= len(self.data):
+            raise TimeoutError()
+        chunk = self.data[self.pos : self.pos + n]
+        self.pos += len(chunk)
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+@pytest.mark.unit
+def test_send_diagnostic_sync_functional_multi_response():
+    """A functional broadcast collects one response frame per responding ECU."""
+    routing_resp = _doip_frame(0x0006, b"\x00\x00\x00\x00\x10")
+    ack_resp = _doip_frame(0x8002, b"\x00\x00\x00\x00\x00")
+    uds_resp_1 = _doip_frame(
+        0x8001, struct.pack(">HH", 0x0001, 0x0E00) + bytes.fromhex("62F19011")
+    )
+    uds_resp_2 = _doip_frame(
+        0x8001, struct.pack(">HH", 0x0002, 0x0E00) + bytes.fromhex("62F19022")
+    )
+    fake_sock = _FakeSocket(routing_resp + ack_resp + uds_resp_1 + uds_resp_2)
+
+    req = DoIPSendRequest(
+        host="127.0.0.1",
+        port=13400,
+        source_address=0x0E00,
+        target_address=0x0000,
+        uds_message="22F190",
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.create_connection", return_value=fake_sock),
+        patch("web.api.doip_client.get_state") as mock_get_state,
+    ):
+        mock_get_state.return_value.config_manager.get_ecus_by_functional_address.return_value = [
+            1,
+            2,
+        ]
+        result = _send_diagnostic_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"] == "62F19011"
+    assert result["responses"] == [
+        {"ecu_address": 1, "ecu_address_hex": "0x0001", "response": "62F19011"},
+        {"ecu_address": 2, "ecu_address_hex": "0x0002", "response": "62F19022"},
+    ]
+
+
+@pytest.mark.unit
+def test_send_diagnostic_sync_physical_single_response():
+    """A physical request stops after the first UDS response, even if more frames follow."""
+    routing_resp = _doip_frame(0x0006, b"\x00\x00\x00\x00\x10")
+    ack_resp = _doip_frame(0x8002, b"\x00\x00\x00\x00\x00")
+    uds_resp_1 = _doip_frame(
+        0x8001, struct.pack(">HH", 0x0001, 0x0E00) + bytes.fromhex("62F19011")
+    )
+    uds_resp_2 = _doip_frame(
+        0x8001, struct.pack(">HH", 0x0002, 0x0E00) + bytes.fromhex("62F19022")
+    )
+    fake_sock = _FakeSocket(routing_resp + ack_resp + uds_resp_1 + uds_resp_2)
+
+    req = DoIPSendRequest(
+        host="127.0.0.1",
+        port=13400,
+        source_address=0x0E00,
+        target_address=0x0001,
+        uds_message="22F190",
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.create_connection", return_value=fake_sock),
+        patch("web.api.doip_client.get_state") as mock_get_state,
+    ):
+        mock_get_state.return_value.config_manager.get_ecus_by_functional_address.return_value = (
+            []
+        )
+        result = _send_diagnostic_sync(req)
+
+    assert result["ok"] is True
+    assert result["responses"] == [
+        {"ecu_address": 1, "ecu_address_hex": "0x0001", "response": "62F19011"},
+    ]
+
+
 @pytest.mark.unit
 def test_ws_send_and_receive(web_client):
     mock_result = {
         "ok": True,
         "response": "62F190AA",
+        "responses": [
+            {"ecu_address": 1, "ecu_address_hex": "0x0001", "response": "62F190AA"}
+        ],
         "log": [{"ts": 1, "event": "got_response", "detail": "62F190AA"}],
     }
     with patch(_TARGET, return_value=mock_result):
@@ -122,6 +243,7 @@ def test_ws_send_and_receive(web_client):
     assert done["event"] == "done"
     assert done["ok"] is True
     assert done["response"] == "62F190AA"
+    assert done["responses"] == mock_result["responses"]
 
 
 @pytest.mark.unit

--- a/tests/test_web/test_api_ecus.py
+++ b/tests/test_web/test_api_ecus.py
@@ -35,6 +35,29 @@ def test_get_missing_ecu(web_client):
 
 
 @pytest.mark.unit
+def test_list_functional_addresses(web_client):
+    r = web_client.get("/api/ecus/functional-addresses")
+    assert r.status_code == 200
+    groups = r.json()
+    assert isinstance(groups, list)
+    assert len(groups) > 0
+
+    group = groups[0]
+    for field in ("functional_address", "functional_address_hex", "ecus", "services"):
+        assert field in group, f"Missing field: {field}"
+
+    # gateway1.yaml has every ECU on functional address 0x0000, sharing
+    # services like Read_VIN that support functional addressing.
+    assert group["functional_address_hex"] == "0x0000"
+    assert len(group["ecus"]) > 1
+    service_names = [s["name"] for s in group["services"]]
+    assert "Read_VIN" in service_names
+    read_vin = next(s for s in group["services"] if s["name"] == "Read_VIN")
+    assert read_vin["request"] == "0x22F190"
+    assert len(read_vin["ecus"]) > 1
+
+
+@pytest.mark.unit
 def test_create_and_delete_ecu(web_client):
     new_ecu = {
         "target_address": 0x00FF,


### PR DESCRIPTION
## Summary
- Closes #122
- The web DoIP client tester now reads one UDS response frame per responding ECU for functional (broadcast) requests and returns them as a `responses` list, in addition to the existing single `response` field.
- New `GET /api/ecus/functional-addresses` endpoint groups ECUs by functional address and lists the services each group supports for functional addressing.
- `/client` page gains a "Send as functional (broadcast)" toggle that swaps the ECU/service pickers for a functional-group/service picker, and the response panel renders a row per responding ECU.

## Test plan
- [x] `poetry run pytest tests/test_web/ -v` — 49 passed
- [x] `poetry run pytest tests/ -q` — 333 passed, 6 skipped
- [x] Manual: ran `web.app` against `config/gateway1.yaml`, sent a functional broadcast `Read_VIN` (target `0x0000`) and confirmed 8 responses (one per ECU)
- [x] Manual: confirmed physical (single-ECU) requests still return one response with no added latency