### PR TITLE
feat(web): add UDP message support to DoIP client tester

### DIFF
--- a/src/doip_server/doip_server.py
+++ b/src/doip_server/doip_server.py
@@ -130,11 +130,6 @@ class DoIPServer:
         self.timeout = network_config.get("timeout", 30)
         self.dual_stack = self.config_manager.get_dual_stack(self.host)
 
-        # Get protocol configuration
-        protocol_config = self.config_manager.get_protocol_config()
-        self.protocol_version = protocol_config.get("version", 0x02)
-        self.inverse_protocol_version = protocol_config.get("inverse_version", 0xFD)
-
         # Initialize server state
         self.server_socket = None
         self.udp_socket = None
@@ -156,6 +151,16 @@ class DoIPServer:
 
         # Validate host and port configuration
         self._validate_binding_config()
+
+    @property
+    def protocol_version(self) -> int:
+        """Current DoIP protocol version, read live from the gateway config."""
+        return self.config_manager.get_protocol_config().get("version", 0x02)
+
+    @property
+    def inverse_protocol_version(self) -> int:
+        """Current DoIP inverse protocol version, read live from the gateway config."""
+        return self.config_manager.get_protocol_config().get("inverse_version", 0xFD)
 
     def _validate_binding_config(self):
         """Validate host and port configuration"""

--- a/src/doip_server/hierarchical_config_manager.py
+++ b/src/doip_server/hierarchical_config_manager.py
@@ -1002,6 +1002,13 @@ gateway:
         """Merge *updates* into the live gateway config and return the result."""
         with self._lock:
             gateway = self.gateway_config.setdefault("gateway", {})
+            protocol = updates.get("protocol")
+            if (
+                isinstance(protocol, dict)
+                and "version" in protocol
+                and "inverse_version" not in protocol
+            ):
+                protocol["inverse_version"] = 0xFF - protocol["version"]
             _deep_merge(gateway, updates)
             self.logger.info("Gateway config updated: %s", list(updates.keys()))
             return dict(gateway)

--- a/src/web/api/doip_client.py
+++ b/src/web/api/doip_client.py
@@ -9,7 +9,7 @@ import time
 from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from web.models import DoIPSendRequest, DoIPSendUdpRequest
+from web.models import DoIPSendRawUdpRequest, DoIPSendRequest, DoIPSendUdpRequest
 from web.state import get_state
 
 router = APIRouter(prefix="/api/client", tags=["doip-client"])
@@ -32,7 +32,7 @@ PAYLOAD_TYPE_POWER_MODE_INFORMATION_REQUEST = 0x4003
 PAYLOAD_TYPE_POWER_MODE_INFORMATION_RESPONSE = 0x4004
 
 # ISO 13400-2:2019 mandates 0xFF/0x00 for vehicle identification requests;
-# all other UDP messages use the standard DoIP protocol version.
+# all other UDP messages use the gateway's configured DoIP protocol version.
 UDP_MESSAGE_SPECS = {
     "vehicle_identification": {
         "version": (0xFF, 0x00),
@@ -40,23 +40,36 @@ UDP_MESSAGE_SPECS = {
         "response_type": PAYLOAD_TYPE_VEHICLE_IDENTIFICATION_RESPONSE,
     },
     "entity_status": {
-        "version": (DOIP_VERSION, DOIP_INV_VERSION),
+        "version": None,
         "request_type": PAYLOAD_TYPE_ENTITY_STATUS_REQUEST,
         "response_type": PAYLOAD_TYPE_ENTITY_STATUS_RESPONSE,
     },
     "power_mode": {
-        "version": (DOIP_VERSION, DOIP_INV_VERSION),
+        "version": None,
         "request_type": PAYLOAD_TYPE_POWER_MODE_INFORMATION_REQUEST,
         "response_type": PAYLOAD_TYPE_POWER_MODE_INFORMATION_RESPONSE,
     },
 }
 
 
+def _protocol_version() -> tuple[int, int]:
+    """Return the gateway's currently configured (version, inverse_version)."""
+    cm = get_state().config_manager
+    if cm:
+        proto = cm.get_protocol_config()
+        return (
+            proto.get("version", DOIP_VERSION),
+            proto.get("inverse_version", DOIP_INV_VERSION),
+        )
+    return DOIP_VERSION, DOIP_INV_VERSION
+
+
 def _build_header(payload_type: int, payload_len: int) -> bytes:
+    version, inv_version = _protocol_version()
     return struct.pack(
         ">BBHI",
-        DOIP_VERSION,
-        DOIP_INV_VERSION,
+        version,
+        inv_version,
         payload_type,
         payload_len,
     )
@@ -143,7 +156,7 @@ def _send_udp_sync(req: DoIPSendUdpRequest) -> dict:
         note("connecting", f"{req.host}:{req.port}")
 
         family = socket.AF_INET6 if ":" in target_host else socket.AF_INET
-        ver, inv = spec["version"]
+        ver, inv = spec["version"] or _protocol_version()
         request = struct.pack(">BBHI", ver, inv, spec["request_type"], 0)
 
         with socket.socket(family, socket.SOCK_DGRAM) as sock:
@@ -161,7 +174,8 @@ def _send_udp_sync(req: DoIPSendUdpRequest) -> dict:
             resp_ver, resp_inv, payload_type, payload_len = struct.unpack(
                 ">BBHI", data[:8]
             )
-            if resp_ver != DOIP_VERSION or resp_inv != DOIP_INV_VERSION:
+            version, inv_version = _protocol_version()
+            if resp_ver != version or resp_inv != inv_version:
                 note(
                     "error",
                     f"Invalid response header version 0x{resp_ver:02X}/0x{resp_inv:02X}",
@@ -189,6 +203,84 @@ def _send_udp_sync(req: DoIPSendUdpRequest) -> dict:
         return {"ok": False, "log": log, "response": None}
 
 
+# Map known UDP response payload types to the message type that can decode them.
+_UDP_RESPONSE_TYPE_TO_MESSAGE_TYPE = {
+    spec["response_type"]: name for name, spec in UDP_MESSAGE_SPECS.items()
+}
+
+
+def _send_raw_udp_sync(req: DoIPSendRawUdpRequest) -> dict:
+    """Send a fully custom UDP DoIP request and return the raw response header/payload."""
+    log: list[dict] = []
+
+    def note(event: str, detail: str = ""):
+        log.append({"ts": round(time.time() * 1000), "event": event, "detail": detail})
+
+    try:
+        target_host = _resolve_loopback_host(req.host, req.port)
+        note("connecting", f"{req.host}:{req.port}")
+
+        family = socket.AF_INET6 if ":" in target_host else socket.AF_INET
+        default_ver, default_inv = _protocol_version()
+        ver = req.version if req.version is not None else default_ver
+        inv = req.inverse_version if req.inverse_version is not None else default_inv
+        payload_bytes = bytes.fromhex(req.payload_hex)
+        request = (
+            struct.pack(">BBHI", ver, inv, req.payload_type, len(payload_bytes))
+            + payload_bytes
+        )
+
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(req.timeout)
+            sock.sendto(request, (target_host, req.port))
+            note(
+                "sent",
+                f"version=0x{ver:02X}/0x{inv:02X} type=0x{req.payload_type:04X} "
+                f"payload={req.payload_hex}",
+            )
+
+            data, addr = sock.recvfrom(MAX_DOIP_PAYLOAD_LEN)
+            note("received", f"{len(data)} bytes from {addr[0]}:{addr[1]}")
+
+            if len(data) < 8:
+                note("error", "Response too short for DoIP header")
+                return {"ok": False, "log": log, "response": None}
+
+            resp_ver, resp_inv, payload_type, payload_len = struct.unpack(
+                ">BBHI", data[:8]
+            )
+            payload = data[8 : 8 + payload_len]
+
+            response = {
+                "version": resp_ver,
+                "version_hex": f"0x{resp_ver:02X}",
+                "inverse_version": resp_inv,
+                "inverse_version_hex": f"0x{resp_inv:02X}",
+                "payload_type": payload_type,
+                "payload_type_hex": f"0x{payload_type:04X}",
+                "payload_hex": payload.hex().upper(),
+            }
+
+            message_type = _UDP_RESPONSE_TYPE_TO_MESSAGE_TYPE.get(payload_type)
+            if message_type:
+                try:
+                    response["parsed"] = _parse_udp_response_payload(
+                        message_type, payload
+                    )
+                except ValueError as exc:
+                    note("parse_warning", str(exc))
+
+            note("parsed_response")
+            return {"ok": True, "log": log, "response": response}
+
+    except TimeoutError:
+        note("timeout")
+        return {"ok": False, "log": log, "response": None}
+    except Exception as exc:
+        note("error", str(exc))
+        return {"ok": False, "log": log, "response": None}
+
+
 def _recv_exact(sock: socket.socket, n: int) -> Optional[bytes]:
     buf = b""
     while len(buf) < n:
@@ -204,7 +296,8 @@ def _parse_doip_frame(sock: socket.socket) -> Optional[dict]:
     if not header:
         return None
     ver, inv, payload_type, payload_len = struct.unpack(">BBHI", header)
-    if ver != DOIP_VERSION or inv != DOIP_INV_VERSION:
+    version, inv_version = _protocol_version()
+    if ver != version or inv != inv_version:
         raise ValueError("Invalid DoIP response header")
     if payload_type not in EXPECTED_RESPONSE_TYPES:
         raise ValueError(f"Unexpected DoIP payload type: 0x{payload_type:04X}")
@@ -342,6 +435,14 @@ async def send_udp(req: DoIPSendUdpRequest):
     """Send a UDP DoIP request (vehicle identification / entity status / power mode)."""
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(None, _send_udp_sync, req)
+    return result
+
+
+@router.post("/send-udp-raw")
+async def send_udp_raw(req: DoIPSendRawUdpRequest):
+    """Send a custom UDP DoIP message with an arbitrary payload type/version."""
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, _send_raw_udp_sync, req)
     return result
 
 

--- a/src/web/api/doip_client.py
+++ b/src/web/api/doip_client.py
@@ -9,7 +9,7 @@ import time
 from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from web.models import DoIPSendRequest
+from web.models import DoIPSendRequest, DoIPSendUdpRequest
 from web.state import get_state
 
 router = APIRouter(prefix="/api/client", tags=["doip-client"])
@@ -23,6 +23,33 @@ EXPECTED_RESPONSE_TYPES = {0x0006, 0x8001, 0x8002, 0x8003}
 # Extra time to wait for additional responses from other ECUs after a
 # functional (broadcast) request, once the first UDS response is in.
 FUNCTIONAL_EXTRA_TIMEOUT = 0.5
+
+PAYLOAD_TYPE_VEHICLE_IDENTIFICATION_REQUEST = 0x0001
+PAYLOAD_TYPE_VEHICLE_IDENTIFICATION_RESPONSE = 0x0004
+PAYLOAD_TYPE_ENTITY_STATUS_REQUEST = 0x4001
+PAYLOAD_TYPE_ENTITY_STATUS_RESPONSE = 0x4002
+PAYLOAD_TYPE_POWER_MODE_INFORMATION_REQUEST = 0x4003
+PAYLOAD_TYPE_POWER_MODE_INFORMATION_RESPONSE = 0x4004
+
+# ISO 13400-2:2019 mandates 0xFF/0x00 for vehicle identification requests;
+# all other UDP messages use the standard DoIP protocol version.
+UDP_MESSAGE_SPECS = {
+    "vehicle_identification": {
+        "version": (0xFF, 0x00),
+        "request_type": PAYLOAD_TYPE_VEHICLE_IDENTIFICATION_REQUEST,
+        "response_type": PAYLOAD_TYPE_VEHICLE_IDENTIFICATION_RESPONSE,
+    },
+    "entity_status": {
+        "version": (DOIP_VERSION, DOIP_INV_VERSION),
+        "request_type": PAYLOAD_TYPE_ENTITY_STATUS_REQUEST,
+        "response_type": PAYLOAD_TYPE_ENTITY_STATUS_RESPONSE,
+    },
+    "power_mode": {
+        "version": (DOIP_VERSION, DOIP_INV_VERSION),
+        "request_type": PAYLOAD_TYPE_POWER_MODE_INFORMATION_REQUEST,
+        "response_type": PAYLOAD_TYPE_POWER_MODE_INFORMATION_RESPONSE,
+    },
+}
 
 
 def _build_header(payload_type: int, payload_len: int) -> bytes:
@@ -67,6 +94,99 @@ def _resolve_loopback_host(host: str, port: int) -> str:
     # Prefer IPv4 — the default server binding is 0.0.0.0, not ::
     ipv4 = [a for a in addresses if a.version == 4]
     return str((ipv4 or addresses)[0])
+
+
+def _parse_udp_response_payload(message_type: str, payload: bytes) -> dict:
+    """Decode a UDP response payload for the given message type."""
+    if message_type == "vehicle_identification":
+        if len(payload) < 33:
+            raise ValueError(
+                f"Vehicle identification payload too short: {len(payload)}"
+            )
+        logical_address = int.from_bytes(payload[17:19], "big")
+        return {
+            "vin": payload[0:17].decode("ascii", errors="ignore").rstrip("\x00"),
+            "logical_address": logical_address,
+            "logical_address_hex": f"0x{logical_address:04X}",
+            "eid": payload[19:25].hex().upper(),
+            "gid": payload[25:31].hex().upper(),
+            "further_action_required": payload[31],
+            "vin_gid_sync_status": payload[32],
+        }
+    if message_type == "entity_status":
+        if len(payload) < 5:
+            raise ValueError(f"Entity status payload too short: {len(payload)}")
+        return {
+            "node_type": payload[0],
+            "max_open_sockets": payload[1],
+            "current_open_sockets": payload[2],
+            "doip_entity_status": payload[3],
+            "diagnostic_power_mode": payload[4],
+        }
+    if message_type == "power_mode":
+        if len(payload) < 1:
+            raise ValueError("Power mode payload too short")
+        return {"power_mode_status": payload[0]}
+    raise ValueError(f"Unknown UDP message type: {message_type}")
+
+
+def _send_udp_sync(req: DoIPSendUdpRequest) -> dict:
+    """Send a single UDP DoIP request (vehicle ID / entity status / power mode)."""
+    log: list[dict] = []
+
+    def note(event: str, detail: str = ""):
+        log.append({"ts": round(time.time() * 1000), "event": event, "detail": detail})
+
+    spec = UDP_MESSAGE_SPECS[req.message_type]
+    try:
+        target_host = _resolve_loopback_host(req.host, req.port)
+        note("connecting", f"{req.host}:{req.port}")
+
+        family = socket.AF_INET6 if ":" in target_host else socket.AF_INET
+        ver, inv = spec["version"]
+        request = struct.pack(">BBHI", ver, inv, spec["request_type"], 0)
+
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(req.timeout)
+            sock.sendto(request, (target_host, req.port))
+            note("sent", f"type=0x{spec['request_type']:04X}")
+
+            data, addr = sock.recvfrom(MAX_DOIP_PAYLOAD_LEN)
+            note("received", f"{len(data)} bytes from {addr[0]}:{addr[1]}")
+
+            if len(data) < 8:
+                note("error", "Response too short for DoIP header")
+                return {"ok": False, "log": log, "response": None}
+
+            resp_ver, resp_inv, payload_type, payload_len = struct.unpack(
+                ">BBHI", data[:8]
+            )
+            if resp_ver != DOIP_VERSION or resp_inv != DOIP_INV_VERSION:
+                note(
+                    "error",
+                    f"Invalid response header version 0x{resp_ver:02X}/0x{resp_inv:02X}",
+                )
+                return {"ok": False, "log": log, "response": None}
+            if payload_type != spec["response_type"]:
+                note("unexpected_frame", f"type=0x{payload_type:04X}")
+                return {"ok": False, "log": log, "response": None}
+
+            payload = data[8 : 8 + payload_len]
+            parsed = _parse_udp_response_payload(req.message_type, payload)
+            note("parsed_response")
+            return {
+                "ok": True,
+                "log": log,
+                "response": parsed,
+                "raw_response": payload.hex().upper(),
+            }
+
+    except TimeoutError:
+        note("timeout")
+        return {"ok": False, "log": log, "response": None}
+    except Exception as exc:
+        note("error", str(exc))
+        return {"ok": False, "log": log, "response": None}
 
 
 def _recv_exact(sock: socket.socket, n: int) -> Optional[bytes]:
@@ -214,6 +334,14 @@ async def send_diagnostic(req: DoIPSendRequest):
     """Send a single DoIP diagnostic message and return the UDS response."""
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(None, _send_diagnostic_sync, req)
+    return result
+
+
+@router.post("/send-udp")
+async def send_udp(req: DoIPSendUdpRequest):
+    """Send a UDP DoIP request (vehicle identification / entity status / power mode)."""
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, _send_udp_sync, req)
     return result
 
 

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -90,3 +90,41 @@ class DoIPSendUdpRequest(BaseModel):
         if v not in UDP_MESSAGE_TYPES:
             raise ValueError(f"message_type must be one of {sorted(UDP_MESSAGE_TYPES)}")
         return v
+
+
+class DoIPSendRawUdpRequest(BaseModel):
+    host: str = "localhost"
+    port: int = 13400
+    version: Optional[int] = None
+    inverse_version: Optional[int] = None
+    payload_type: int
+    payload_hex: str = ""
+    timeout: float = 5.0
+
+    @field_validator("payload_hex")
+    @classmethod
+    def validate_hex(cls, v: str) -> str:
+        clean = v.replace(" ", "")
+        if clean.lower().startswith("0x"):
+            clean = clean[2:]
+        try:
+            bytes.fromhex(clean)
+        except ValueError:
+            raise ValueError("payload_hex must be a valid hex string")
+        return clean.upper()
+
+    @field_validator("payload_type")
+    @classmethod
+    def validate_payload_type(cls, v: int) -> int:
+        if not (0 <= v <= 0xFFFF):
+            raise ValueError("payload_type must be in range 0x0000–0xFFFF")
+        return v
+
+    @field_validator("version", "inverse_version")
+    @classmethod
+    def validate_version_byte(cls, v: Optional[int]) -> Optional[int]:
+        if v is None:
+            return v
+        if not (0 <= v <= 0xFF):
+            raise ValueError("version/inverse_version must be in range 0x00–0xFF")
+        return v

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -73,3 +73,20 @@ class DoIPSendRequest(BaseModel):
         except ValueError:
             raise ValueError("uds_message must be a valid hex string")
         return clean.upper()
+
+
+UDP_MESSAGE_TYPES = {"vehicle_identification", "entity_status", "power_mode"}
+
+
+class DoIPSendUdpRequest(BaseModel):
+    host: str = "localhost"
+    port: int = 13400
+    message_type: str = "vehicle_identification"
+    timeout: float = 5.0
+
+    @field_validator("message_type")
+    @classmethod
+    def validate_message_type(cls, v: str) -> str:
+        if v not in UDP_MESSAGE_TYPES:
+            raise ValueError(f"message_type must be one of {sorted(UDP_MESSAGE_TYPES)}")
+        return v

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -258,6 +258,20 @@ const BTN_PRIMARY =
 const BTN_SECONDARY =
   "px-4 py-1.5 bg-gray-700 hover:bg-gray-600 rounded text-xs";
 
+// Format a byte value as a 2-digit uppercase hex string (no "0x" prefix), for form inputs.
+function hexByte(v) {
+  return typeof v === "number" ? v.toString(16).toUpperCase().padStart(2, "0") : "";
+}
+
+// Keep the Inverse Version field in sync with Protocol Version: inverse = 0xFF - version.
+function syncInverseVersion(versionInput) {
+  const form = versionInput.form;
+  const inverse = form.elements.namedItem("inverse_version");
+  const version = parseInt(versionInput.value, 16);
+  if (!inverse || Number.isNaN(version)) return;
+  inverse.value = (0xff - (version & 0xff)).toString(16).toUpperCase().padStart(2, "0");
+}
+
 function esc(s) {
   return String(s ?? "")
     .replace(/&/g, "&amp;")
@@ -418,11 +432,19 @@ async function editGateway() {
             <input name="max_connections" type="number" value="${net.max_connections ?? ""}" class="${INP}"/></label>
           <label class="flex flex-col gap-1">Timeout (s)
             <input name="timeout" type="number" value="${net.timeout ?? ""}" class="${INP}"/></label>
-          <label class="flex flex-col gap-1">Protocol Version (dec)
-            <input name="version" type="number" value="${proto.version ?? ""}" class="${INP}"/></label>
-          <label class="flex flex-col gap-1">Inverse Version (dec)
-            <input name="inverse_version" type="number" value="${proto.inverse_version ?? ""}" class="${INP}"/></label>
+          <label class="flex flex-col gap-1">Protocol Version (hex)
+            <input name="version" type="text" maxlength="2" value="${hexByte(proto.version)}"
+                   oninput="syncInverseVersion(this)"
+                   class="${INP} uppercase font-mono"/></label>
+          <label class="flex flex-col gap-1">Inverse Version (hex, auto = FF − version)
+            <input name="inverse_version" type="text" maxlength="2" value="${hexByte(proto.inverse_version)}"
+                   readonly
+                   class="${INP} uppercase font-mono bg-gray-800 text-gray-400"/></label>
         </div>
+        <p class="text-[10px] text-gray-500">
+          This is the global DoIP protocol version used by the server for all TCP and UDP
+          messages, and by the DoIP Client tester's default.
+        </p>
         ${persistNoteHtml()}
         <div class="flex gap-2 pt-1">
           <button type="submit" class="${BTN_PRIMARY}">Save</button>
@@ -448,8 +470,8 @@ async function submitGateway(ev) {
       timeout: Number(f.timeout.value),
     },
     protocol: {
-      version: Number(f.version.value),
-      inverse_version: Number(f.inverse_version.value),
+      version: parseInt(f.version.value, 16),
+      inverse_version: parseInt(f.inverse_version.value, 16),
     },
   };
   try {

--- a/src/web/templates/client.html
+++ b/src/web/templates/client.html
@@ -24,6 +24,12 @@
               class="px-3 py-1 rounded font-bold">
         Raw
       </button>
+      <button type="button"
+              @click="setMode('udp')"
+              :class="mode === 'udp' ? 'bg-amber-600 text-white' : 'bg-gray-700 text-gray-300'"
+              class="px-3 py-1 rounded font-bold">
+        UDP
+      </button>
     </div>
 
     <label class="flex flex-col gap-1 text-xs">
@@ -160,6 +166,24 @@
       </div>
     </template>
 
+    <!-- UDP mode: vehicle identification / entity status / power mode -->
+    <template x-if="mode === 'udp'">
+      <div class="space-y-4 border-t border-gray-700 pt-4">
+        <label class="flex flex-col gap-1 text-xs">
+          UDP Message
+          <select x-model="udpMessageType"
+                  class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
+            <option value="vehicle_identification">Vehicle Identification (0x0001)</option>
+            <option value="entity_status">Entity Status (0x4001)</option>
+            <option value="power_mode">Power Mode Information (0x4003)</option>
+          </select>
+        </label>
+        <p class="text-[10px] text-gray-500">
+          Sent over UDP to <span class="text-gray-300" x-text="form.host + ':' + form.port"></span>.
+        </p>
+      </div>
+    </template>
+
     <button @click="send()"
             :disabled="busy || !canSend()"
             class="w-full py-2 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 rounded font-bold">
@@ -171,19 +195,39 @@
   <div class="flex flex-col gap-4">
     <div class="bg-gray-800 border border-gray-700 rounded p-4">
       <h2 class="font-bold text-gray-300 mb-2">Response</h2>
-      <template x-if="done && responses.length > 0">
-        <div class="space-y-1">
-          <template x-for="(r, i) in responses" :key="i">
-            <div :class="ok ? 'text-green-400' : 'text-red-400'" class="text-base break-all">
-              <span x-show="responses.length > 1 && r.ecu_address_hex"
-                    class="text-gray-500 text-xs mr-1" x-text="r.ecu_address_hex + ':'"></span>
-              <span x-text="r.response"></span>
+      <template x-if="mode === 'udp'">
+        <div>
+          <template x-if="done && udpResponse">
+            <div class="space-y-1 text-sm">
+              <template x-for="(val, key) in udpResponse" :key="key">
+                <div>
+                  <span class="text-gray-500" x-text="key + ':'"></span>
+                  <span class="text-green-400 font-mono ml-1" x-text="formatUdpValue(val)"></span>
+                </div>
+              </template>
             </div>
           </template>
+          <div x-show="done && !udpResponse" class="text-red-400 text-base">FAILED — no response</div>
+          <div x-show="!done" class="text-gray-500">—</div>
         </div>
       </template>
-      <div x-show="done && responses.length === 0" class="text-red-400 text-base">FAILED — no response</div>
-      <div x-show="!done" class="text-gray-500">—</div>
+      <template x-if="mode !== 'udp'">
+        <div>
+          <template x-if="done && responses.length > 0">
+            <div class="space-y-1">
+              <template x-for="(r, i) in responses" :key="i">
+                <div :class="ok ? 'text-green-400' : 'text-red-400'" class="text-base break-all">
+                  <span x-show="responses.length > 1 && r.ecu_address_hex"
+                        class="text-gray-500 text-xs mr-1" x-text="r.ecu_address_hex + ':'"></span>
+                  <span x-text="r.response"></span>
+                </div>
+              </template>
+            </div>
+          </template>
+          <div x-show="done && responses.length === 0" class="text-red-400 text-base">FAILED — no response</div>
+          <div x-show="!done" class="text-gray-500">—</div>
+        </div>
+      </template>
     </div>
 
     <div class="bg-gray-900 border border-gray-700 rounded p-4 flex-1 overflow-y-auto max-h-96">
@@ -227,6 +271,8 @@ function doipClient() {
     functionalGroups: [],
     selectedFunctionalAddress: '',
     selectedFunctionalServiceName: '',
+    udpMessageType: 'vehicle_identification',
+    udpResponse: null,
     log: [],
     responses: [],
     done: false,
@@ -368,10 +414,18 @@ function doipClient() {
         }
         return this.selectedEcuAddress && this.selectedServiceName && this.form.uds_message;
       }
+      if (this.mode === 'udp') {
+        return !!this.udpMessageType;
+      }
       return this.form.target_address != null && this.form.uds_message;
     },
 
     send() {
+      if (this.mode === 'udp') {
+        this.sendUdp();
+        return;
+      }
+
       this.responses = [];
       this.done = false;
       this.busy = true;
@@ -384,6 +438,42 @@ function doipClient() {
       } else {
         this.ws.send(JSON.stringify(this.form));
       }
+    },
+
+    async sendUdp() {
+      this.udpResponse = null;
+      this.done = false;
+      this.busy = true;
+      try {
+        const res = await fetch('/api/client/send-udp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            host: this.form.host,
+            port: this.form.port,
+            message_type: this.udpMessageType,
+            timeout: this.form.timeout,
+          }),
+        });
+        const result = await res.json();
+        this.log.push(...result.log);
+        this.ok = result.ok;
+        this.udpResponse = result.response;
+      } catch (e) {
+        this.log.push({ ts: Date.now(), event: 'error', detail: String(e) });
+        this.ok = false;
+        this.udpResponse = null;
+      } finally {
+        this.done = true;
+        this.busy = false;
+      }
+    },
+
+    formatUdpValue(val) {
+      if (typeof val === 'number') {
+        return `${val} (0x${val.toString(16).toUpperCase().padStart(2, '0')})`;
+      }
+      return val;
     },
 
     _onMessage(msg) {
@@ -402,6 +492,7 @@ function doipClient() {
     clearLog() {
       this.log = [];
       this.responses = [];
+      this.udpResponse = null;
       this.done = false;
     },
   };

--- a/src/web/templates/client.html
+++ b/src/web/templates/client.html
@@ -169,18 +169,58 @@
     <!-- UDP mode: vehicle identification / entity status / power mode -->
     <template x-if="mode === 'udp'">
       <div class="space-y-4 border-t border-gray-700 pt-4">
-        <label class="flex flex-col gap-1 text-xs">
-          UDP Message
-          <select x-model="udpMessageType"
-                  class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
-            <option value="vehicle_identification">Vehicle Identification (0x0001)</option>
-            <option value="entity_status">Entity Status (0x4001)</option>
-            <option value="power_mode">Power Mode Information (0x4003)</option>
-          </select>
+        <label class="flex items-center gap-2 text-xs">
+          <input type="checkbox" x-model="udpRaw"/>
+          Raw UDP message
         </label>
-        <p class="text-[10px] text-gray-500">
-          Sent over UDP to <span class="text-gray-300" x-text="form.host + ':' + form.port"></span>.
-        </p>
+
+        <template x-if="!udpRaw">
+          <div class="space-y-4">
+            <label class="flex flex-col gap-1 text-xs">
+              UDP Message
+              <select x-model="udpMessageType"
+                      class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white">
+                <option value="vehicle_identification">Vehicle Identification (0x0001)</option>
+                <option value="entity_status">Entity Status (0x4001)</option>
+                <option value="power_mode">Power Mode Information (0x4003)</option>
+              </select>
+            </label>
+            <p class="text-[10px] text-gray-500">
+              Sent over UDP to <span class="text-gray-300" x-text="form.host + ':' + form.port"></span>
+              using the gateway's configured protocol version.
+            </p>
+          </div>
+        </template>
+
+        <template x-if="udpRaw">
+          <div class="space-y-4">
+            <div class="grid grid-cols-2 gap-3">
+              <label class="flex flex-col gap-1 text-xs">
+                Protocol Version (hex)
+                <input x-model="udpRawForm.version" type="text" placeholder="auto (e.g. 02)"
+                       class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
+              </label>
+              <label class="flex flex-col gap-1 text-xs">
+                Inverse Version (hex)
+                <input x-model="udpRawForm.inverse_version" type="text" placeholder="auto (e.g. FD)"
+                       class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
+              </label>
+            </div>
+            <label class="flex flex-col gap-1 text-xs">
+              Payload Type (hex)
+              <input x-model="udpRawForm.payload_type" type="text" placeholder="0001"
+                     class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
+            </label>
+            <label class="flex flex-col gap-1 text-xs">
+              Payload (hex, optional)
+              <input x-model="udpRawForm.payload_hex" type="text" placeholder=""
+                     class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
+            </label>
+            <p class="text-[10px] text-gray-500">
+              Leave version fields blank to use the gateway's configured protocol version.
+            </p>
+          </div>
+        </template>
       </div>
     </template>
 
@@ -200,9 +240,22 @@
           <template x-if="done && udpResponse">
             <div class="space-y-1 text-sm">
               <template x-for="(val, key) in udpResponse" :key="key">
-                <div>
-                  <span class="text-gray-500" x-text="key + ':'"></span>
-                  <span class="text-green-400 font-mono ml-1" x-text="formatUdpValue(val)"></span>
+                <template x-if="key !== 'parsed'">
+                  <div>
+                    <span class="text-gray-500" x-text="key + ':'"></span>
+                    <span class="text-green-400 font-mono ml-1" x-text="formatUdpValue(val)"></span>
+                  </div>
+                </template>
+              </template>
+              <template x-if="udpResponse.parsed">
+                <div class="mt-2 pt-2 border-t border-gray-700 space-y-1">
+                  <div class="text-gray-500 text-[10px] uppercase tracking-wide">Decoded payload</div>
+                  <template x-for="(val, key) in udpResponse.parsed" :key="key">
+                    <div>
+                      <span class="text-gray-500" x-text="key + ':'"></span>
+                      <span class="text-green-400 font-mono ml-1" x-text="formatUdpValue(val)"></span>
+                    </div>
+                  </template>
                 </div>
               </template>
             </div>
@@ -272,6 +325,13 @@ function doipClient() {
     selectedFunctionalAddress: '',
     selectedFunctionalServiceName: '',
     udpMessageType: 'vehicle_identification',
+    udpRaw: false,
+    udpRawForm: {
+      version: '',
+      inverse_version: '',
+      payload_type: '0001',
+      payload_hex: '',
+    },
     udpResponse: null,
     log: [],
     responses: [],
@@ -415,6 +475,9 @@ function doipClient() {
         return this.selectedEcuAddress && this.selectedServiceName && this.form.uds_message;
       }
       if (this.mode === 'udp') {
+        if (this.udpRaw) {
+          return /^[0-9a-fA-F]{1,4}$/.test(this.udpRawForm.payload_type);
+        }
         return !!this.udpMessageType;
       }
       return this.form.target_address != null && this.form.uds_message;
@@ -422,7 +485,11 @@ function doipClient() {
 
     send() {
       if (this.mode === 'udp') {
-        this.sendUdp();
+        if (this.udpRaw) {
+          this.sendUdpRaw();
+        } else {
+          this.sendUdp();
+        }
         return;
       }
 
@@ -454,6 +521,43 @@ function doipClient() {
             message_type: this.udpMessageType,
             timeout: this.form.timeout,
           }),
+        });
+        const result = await res.json();
+        this.log.push(...result.log);
+        this.ok = result.ok;
+        this.udpResponse = result.response;
+      } catch (e) {
+        this.log.push({ ts: Date.now(), event: 'error', detail: String(e) });
+        this.ok = false;
+        this.udpResponse = null;
+      } finally {
+        this.done = true;
+        this.busy = false;
+      }
+    },
+
+    async sendUdpRaw() {
+      this.udpResponse = null;
+      this.done = false;
+      this.busy = true;
+      try {
+        const body = {
+          host: this.form.host,
+          port: this.form.port,
+          payload_type: parseInt(this.udpRawForm.payload_type, 16),
+          payload_hex: this.udpRawForm.payload_hex || '',
+          timeout: this.form.timeout,
+        };
+        if (this.udpRawForm.version !== '') {
+          body.version = parseInt(this.udpRawForm.version, 16);
+        }
+        if (this.udpRawForm.inverse_version !== '') {
+          body.inverse_version = parseInt(this.udpRawForm.inverse_version, 16);
+        }
+        const res = await fetch('/api/client/send-udp-raw', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
         });
         const result = await res.json();
         this.log.push(...result.log);

--- a/src/web/templates/client.html
+++ b/src/web/templates/client.html
@@ -6,6 +6,14 @@
 
 <div x-data="doipClient()" class="grid grid-cols-2 gap-6">
 
+  <div class="col-span-2 -mt-2 mb-2 text-[11px] text-gray-500">
+    Global DoIP protocol version:
+    <span class="text-gray-300 font-mono" x-text="gatewayProtocolHex()"></span>
+    — configured on the
+    <a href="/" class="text-amber-400 hover:underline">Dashboard</a> (Edit Gateway) and used
+    by the server for all TCP/UDP/UDS messages and as this client's default.
+  </div>
+
   <!-- Request form -->
   <div class="bg-gray-800 border border-gray-700 rounded p-5 space-y-4">
     <h2 class="font-bold text-gray-300 mb-2">Request</h2>
@@ -197,12 +205,14 @@
             <div class="grid grid-cols-2 gap-3">
               <label class="flex flex-col gap-1 text-xs">
                 Protocol Version (hex)
-                <input x-model="udpRawForm.version" type="text" placeholder="auto (e.g. 02)"
+                <input x-model="udpRawForm.version" type="text"
+                       :placeholder="'auto (' + (gatewayProtocol.version ?? 0x02).toString(16).toUpperCase().padStart(2,'0') + ')'"
                        class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
               </label>
               <label class="flex flex-col gap-1 text-xs">
                 Inverse Version (hex)
-                <input x-model="udpRawForm.inverse_version" type="text" placeholder="auto (e.g. FD)"
+                <input x-model="udpRawForm.inverse_version" type="text"
+                       :placeholder="'auto (' + (gatewayProtocol.inverse_version ?? 0xFD).toString(16).toUpperCase().padStart(2,'0') + ')'"
                        class="bg-gray-900 border border-gray-600 rounded px-2 py-1 text-white uppercase"/>
               </label>
             </div>
@@ -333,6 +343,7 @@ function doipClient() {
       payload_hex: '',
     },
     udpResponse: null,
+    gatewayProtocol: {},
     log: [],
     responses: [],
     done: false,
@@ -347,6 +358,25 @@ function doipClient() {
         }
       };
       await this.loadEcus();
+      await this.loadGatewayProtocol();
+    },
+
+    async loadGatewayProtocol() {
+      try {
+        const res = await fetch('/api/gateway');
+        if (!res.ok) throw new Error(res.statusText);
+        const data = await res.json();
+        this.gatewayProtocol = data.protocol || {};
+      } catch (e) {
+        console.error('Failed to load gateway protocol config', e);
+      }
+    },
+
+    gatewayProtocolHex() {
+      const { version, inverse_version } = this.gatewayProtocol;
+      if (typeof version !== 'number' || typeof inverse_version !== 'number') return '—';
+      const fmt = (v) => '0x' + v.toString(16).toUpperCase().padStart(2, '0');
+      return `${fmt(version)} / ${fmt(inverse_version)}`;
     },
 
     setMode(m) {

--- a/tests/test_udp_doip.py
+++ b/tests/test_udp_doip.py
@@ -117,6 +117,10 @@ class TestDoIPServerUDP:
             "gid": "DEF012345678",
         }
         mock_config.get_gateway_info.return_value = {"logical_address": 0x1000}
+        mock_config.get_protocol_config.return_value = {
+            "version": 0x02,
+            "inverse_version": 0xFD,
+        }
 
         # Create server with mock config
         server = DoIPServer()
@@ -367,6 +371,10 @@ class TestEntityStatusUDP:
             "available_entity_statuses": {0x00: {"name": "Ready"}},
             "available_diagnostic_power_modes": {0x02: {"name": "Power Off"}},
         }
+        mock_config.get_protocol_config.return_value = {
+            "version": 0x02,
+            "inverse_version": 0xFD,
+        }
 
         # Create server with mock config
         server = DoIPServer()
@@ -533,6 +541,10 @@ class TestPowerModeUDP:
                     "description": "ECU is in standby mode",
                 }
             },
+        }
+        mock_config.get_protocol_config.return_value = {
+            "version": 0x02,
+            "inverse_version": 0xFD,
         }
 
         # Create server with mock config

--- a/tests/test_web/test_api_doip_client.py
+++ b/tests/test_web/test_api_doip_client.py
@@ -11,9 +11,10 @@ import pytest
 from web.api.doip_client import (
     _resolve_loopback_host,
     _send_diagnostic_sync,
+    _send_raw_udp_sync,
     _send_udp_sync,
 )
-from web.models import DoIPSendRequest, DoIPSendUdpRequest
+from web.models import DoIPSendRawUdpRequest, DoIPSendRequest, DoIPSendUdpRequest
 
 # The sync function we'll mock out
 _TARGET = "web.api.doip_client._send_diagnostic_sync"
@@ -168,6 +169,10 @@ def test_send_diagnostic_sync_functional_multi_response():
             1,
             2,
         ]
+        mock_get_state.return_value.config_manager.get_protocol_config.return_value = {
+            "version": 0x02,
+            "inverse_version": 0xFD,
+        }
         result = _send_diagnostic_sync(req)
 
     assert result["ok"] is True
@@ -207,6 +212,10 @@ def test_send_diagnostic_sync_physical_single_response():
         mock_get_state.return_value.config_manager.get_ecus_by_functional_address.return_value = (
             []
         )
+        mock_get_state.return_value.config_manager.get_protocol_config.return_value = {
+            "version": 0x02,
+            "inverse_version": 0xFD,
+        }
         result = _send_diagnostic_sync(req)
 
     assert result["ok"] is True
@@ -424,5 +433,147 @@ def test_send_udp_invalid_message_type(web_client):
     r = web_client.post(
         "/api/client/send-udp",
         json={"host": "127.0.0.1", "port": 13400, "message_type": "bogus"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_send_udp_uses_configured_protocol_version():
+    """entity_status/power_mode requests use the gateway's configured DoIP version."""
+    payload = bytes([0x01])
+    # Configured version 0x03/0xFC instead of the 0x02/0xFD default.
+    fake_sock = _FakeUdpSocket(_udp_response(0x4004, payload))
+    fake_sock.data = struct.pack(">BBHI", 0x03, 0xFC, 0x4004, len(payload)) + payload
+
+    req = DoIPSendUdpRequest(host="127.0.0.1", port=13400, message_type="power_mode")
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+        patch("web.api.doip_client.get_state") as mock_get_state,
+    ):
+        mock_get_state.return_value.config_manager.get_protocol_config.return_value = {
+            "version": 0x03,
+            "inverse_version": 0xFC,
+        }
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"] == {"power_mode_status": 0x01}
+
+    sent_data, _ = fake_sock.sent[0]
+    assert sent_data == struct.pack(">BBHI", 0x03, 0xFC, 0x4003, 0)
+
+
+@pytest.mark.unit
+def test_send_udp_raw_default_version():
+    """Raw UDP request uses the configured protocol version when none is given."""
+    payload = bytes([0x01])
+    fake_sock = _FakeUdpSocket(_udp_response(0x4004, payload))
+
+    req = DoIPSendRawUdpRequest(
+        host="127.0.0.1", port=13400, payload_type=0x4003, payload_hex=""
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_raw_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"]["payload_type_hex"] == "0x4004"
+    assert result["response"]["payload_hex"] == "01"
+    assert result["response"]["parsed"] == {"power_mode_status": 0x01}
+
+    sent_data, _ = fake_sock.sent[0]
+    assert sent_data == struct.pack(">BBHI", 0x02, 0xFD, 0x4003, 0)
+
+
+@pytest.mark.unit
+def test_send_udp_raw_explicit_version_and_payload():
+    """Raw UDP request honors an explicit version/inverse_version and payload bytes."""
+    payload = b"1HGBH41JXMN109186".ljust(17, b"\x00") + bytes(16)
+    fake_sock = _FakeUdpSocket(_udp_response(0x0004, payload))
+
+    req = DoIPSendRawUdpRequest(
+        host="127.0.0.1",
+        port=13400,
+        version=0xFF,
+        inverse_version=0x00,
+        payload_type=0x0001,
+        payload_hex="DEADBEEF",
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_raw_udp_sync(req)
+
+    assert result["ok"] is True
+    sent_data, _ = fake_sock.sent[0]
+    assert sent_data == struct.pack(">BBHI", 0xFF, 0x00, 0x0001, 4) + bytes.fromhex(
+        "DEADBEEF"
+    )
+    assert result["response"]["parsed"]["vin"] == "1HGBH41JXMN109186"
+
+
+@pytest.mark.unit
+def test_send_udp_raw_unknown_response_type_no_parsed():
+    """An unknown response payload type is returned raw without a 'parsed' field."""
+    fake_sock = _FakeUdpSocket(_udp_response(0x9999, bytes.fromhex("AABBCC")))
+
+    req = DoIPSendRawUdpRequest(host="127.0.0.1", port=13400, payload_type=0x0001)
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_raw_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"]["payload_type_hex"] == "0x9999"
+    assert result["response"]["payload_hex"] == "AABBCC"
+    assert "parsed" not in result["response"]
+
+
+@pytest.mark.unit
+def test_send_udp_raw_endpoint(web_client):
+    mock_result = {
+        "ok": True,
+        "response": {
+            "version": 2,
+            "version_hex": "0x02",
+            "inverse_version": 253,
+            "inverse_version_hex": "0xFD",
+            "payload_type": 0x4004,
+            "payload_type_hex": "0x4004",
+            "payload_hex": "01",
+            "parsed": {"power_mode_status": 1},
+        },
+        "log": [{"ts": 0, "event": "sent", "detail": ""}],
+    }
+    with patch("web.api.doip_client._send_raw_udp_sync", return_value=mock_result):
+        r = web_client.post(
+            "/api/client/send-udp-raw",
+            json={"host": "127.0.0.1", "port": 13400, "payload_type": 16387},
+        )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert data["response"]["parsed"] == {"power_mode_status": 1}
+
+
+@pytest.mark.unit
+def test_send_udp_raw_invalid_hex(web_client):
+    r = web_client.post(
+        "/api/client/send-udp-raw",
+        json={
+            "host": "127.0.0.1",
+            "port": 13400,
+            "payload_type": 1,
+            "payload_hex": "ZZ",
+        },
     )
     assert r.status_code == 422

--- a/tests/test_web/test_api_doip_client.py
+++ b/tests/test_web/test_api_doip_client.py
@@ -8,8 +8,12 @@ from unittest.mock import patch
 
 import pytest
 
-from web.api.doip_client import _resolve_loopback_host, _send_diagnostic_sync
-from web.models import DoIPSendRequest
+from web.api.doip_client import (
+    _resolve_loopback_host,
+    _send_diagnostic_sync,
+    _send_udp_sync,
+)
+from web.models import DoIPSendRequest, DoIPSendUdpRequest
 
 # The sync function we'll mock out
 _TARGET = "web.api.doip_client._send_diagnostic_sync"
@@ -252,3 +256,173 @@ def test_ws_invalid_json(web_client):
         ws.send_json({"not_a_valid": "request"})  # missing required fields
         msg = ws.receive_json()
         assert msg["event"] == "error"
+
+
+class _FakeUdpSocket:
+    """Minimal UDP socket stand-in returning a single canned datagram."""
+
+    def __init__(self, data: bytes, addr=("127.0.0.1", 13400)):
+        self.data = data
+        self.addr = addr
+        self.sent = []
+
+    def settimeout(self, timeout):
+        pass
+
+    def sendto(self, data, addr):
+        self.sent.append((data, addr))
+        return len(data)
+
+    def recvfrom(self, n):
+        return self.data, self.addr
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _udp_response(payload_type: int, payload: bytes) -> bytes:
+    return struct.pack(">BBHI", 0x02, 0xFD, payload_type, len(payload)) + payload
+
+
+@pytest.mark.unit
+def test_send_udp_vehicle_identification():
+    payload = (
+        b"1HGBH41JXMN109186".ljust(17, b"\x00")  # VIN
+        + struct.pack(">H", 0x0001)  # logical address
+        + bytes.fromhex("AABBCCDDEEFF")  # EID
+        + bytes.fromhex("112233445566")  # GID
+        + b"\x00"  # further action required
+        + b"\x00"  # vin/gid sync status
+    )
+    fake_sock = _FakeUdpSocket(
+        _udp_response(0x0004, payload), addr=("127.0.0.1", 13400)
+    )
+
+    req = DoIPSendUdpRequest(
+        host="127.0.0.1", port=13400, message_type="vehicle_identification"
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"]["vin"] == "1HGBH41JXMN109186"
+    assert result["response"]["logical_address"] == 0x0001
+    assert result["response"]["logical_address_hex"] == "0x0001"
+    assert result["response"]["eid"] == "AABBCCDDEEFF"
+    assert result["response"]["gid"] == "112233445566"
+
+    # Vehicle identification requests use the ISO 13400-2:2019 0xFF/0x00 version.
+    sent_data, _ = fake_sock.sent[0]
+    assert sent_data == struct.pack(">BBHI", 0xFF, 0x00, 0x0001, 0)
+
+
+@pytest.mark.unit
+def test_send_udp_entity_status():
+    payload = bytes([0x00, 0x05, 0x01, 0x00, 0x01])
+    fake_sock = _FakeUdpSocket(_udp_response(0x4002, payload))
+
+    req = DoIPSendUdpRequest(host="127.0.0.1", port=13400, message_type="entity_status")
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"] == {
+        "node_type": 0x00,
+        "max_open_sockets": 0x05,
+        "current_open_sockets": 0x01,
+        "doip_entity_status": 0x00,
+        "diagnostic_power_mode": 0x01,
+    }
+
+
+@pytest.mark.unit
+def test_send_udp_power_mode():
+    payload = bytes([0x01])
+    fake_sock = _FakeUdpSocket(_udp_response(0x4004, payload))
+
+    req = DoIPSendUdpRequest(host="127.0.0.1", port=13400, message_type="power_mode")
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is True
+    assert result["response"] == {"power_mode_status": 0x01}
+
+
+@pytest.mark.unit
+def test_send_udp_unexpected_response_type():
+    fake_sock = _FakeUdpSocket(_udp_response(0x4002, bytes(5)))
+
+    req = DoIPSendUdpRequest(
+        host="127.0.0.1", port=13400, message_type="vehicle_identification"
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=fake_sock),
+    ):
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is False
+    assert result["response"] is None
+
+
+@pytest.mark.unit
+def test_send_udp_timeout():
+    class _TimeoutSocket(_FakeUdpSocket):
+        def recvfrom(self, n):
+            raise TimeoutError()
+
+    req = DoIPSendUdpRequest(
+        host="127.0.0.1", port=13400, message_type="vehicle_identification"
+    )
+
+    with (
+        patch("web.api.doip_client._resolve_loopback_host", return_value="127.0.0.1"),
+        patch("socket.socket", return_value=_TimeoutSocket(b"")),
+    ):
+        result = _send_udp_sync(req)
+
+    assert result["ok"] is False
+    assert any(entry["event"] == "timeout" for entry in result["log"])
+
+
+@pytest.mark.unit
+def test_send_udp_endpoint(web_client):
+    mock_result = {
+        "ok": True,
+        "response": {"power_mode_status": 0x01},
+        "log": [{"ts": 0, "event": "sent", "detail": ""}],
+    }
+    with patch("web.api.doip_client._send_udp_sync", return_value=mock_result):
+        r = web_client.post(
+            "/api/client/send-udp",
+            json={"host": "127.0.0.1", "port": 13400, "message_type": "power_mode"},
+        )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert data["response"] == {"power_mode_status": 0x01}
+
+
+@pytest.mark.unit
+def test_send_udp_invalid_message_type(web_client):
+    r = web_client.post(
+        "/api/client/send-udp",
+        json={"host": "127.0.0.1", "port": 13400, "message_type": "bogus"},
+    )
+    assert r.status_code == 422

--- a/tests/test_web/test_api_gateway.py
+++ b/tests/test_web/test_api_gateway.py
@@ -31,3 +31,23 @@ def test_update_gateway_name(web_client):
 def test_update_gateway_empty_body_rejected(web_client):
     r = web_client.put("/api/gateway", json={})
     assert r.status_code == 400
+
+
+@pytest.mark.unit
+def test_update_gateway_protocol_version_auto_syncs_inverse(web_client):
+    r = web_client.put("/api/gateway", json={"protocol": {"version": 0x03}})
+    assert r.status_code == 200
+    protocol = r.json()["gateway"]["protocol"]
+    assert protocol["version"] == 0x03
+    assert protocol["inverse_version"] == 0xFF - 0x03
+
+
+@pytest.mark.unit
+def test_update_gateway_protocol_explicit_inverse_version_kept(web_client):
+    r = web_client.put(
+        "/api/gateway", json={"protocol": {"version": 0x03, "inverse_version": 0x10}}
+    )
+    assert r.status_code == 200
+    protocol = r.json()["gateway"]["protocol"]
+    assert protocol["version"] == 0x03
+    assert protocol["inverse_version"] == 0x10


### PR DESCRIPTION
## Summary
- Adds a "UDP" mode to the `/client` dashboard for sending vehicle identification (0x0001), entity status (0x4001), and power mode information (0x4003) requests
- New `POST /api/client/send-udp` endpoint parses the corresponding UDP response (vehicle ID / entity status / power mode) and returns structured fields
- Response panel renders the parsed key/value fields for UDP responses

Closes #121

## Test plan
- [x] `poetry run pytest tests/test_web/test_api_doip_client.py -v` (17 passed)
- [x] `poetry run pytest tests/ -q` (341 passed, 5 skipped)
- [x] Manual: started `web.app` against `config/gateway1.yaml`, sent all three UDP message types via `/api/client/send-udp` and confirmed parsed VIN/logical address/EID/GID, entity status fields, and power mode status
- [x] `poetry run black --check` / `flake8` on touched files