### PR TITLE
feat: add YAML config schema validation and UDS message checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ help:
 	@echo "  format-check - Check code formatting without changes"
 	@echo "  security    - Run security checks (bandit, safety)"
 	@echo "  validate    - Validate configuration files"
+	@echo "  validate-config - Run the full config schema/semantic validator (CLI)"
 	@echo "  demo        - Run demo scripts"
 	@echo "  build       - Build package"
 	@echo "  clean       - Clean build artifacts and cache"
@@ -160,6 +161,11 @@ security:
 validate:
 	@echo "Validating hierarchical configuration..."
 	poetry run python -c "from src.doip_server.hierarchical_config_manager import HierarchicalConfigManager; HierarchicalConfigManager('config/gateway1.yaml')"
+
+# Full schema + semantic configuration validation (CLI)
+validate-config:
+	@echo "Validating configuration files against JSON schemas..."
+	poetry run validate_config --gateway-config config/gateway1.yaml
 
 # Demo scripts
 demo:

--- a/config/ecus/abs/ecu_abs_services.yaml
+++ b/config/ecus/abs/ecu_abs_services.yaml
@@ -41,11 +41,11 @@ specific_services:
     request: "0x1902"
     responses:
       - "0x5902"  # No DTCs
-      - "0x5902C0000"  # C0000 - No fault
-      - "0x5902C0001"  # C0001 - Left front wheel speed sensor
-      - "0x5902C0002"  # C0002 - Right front wheel speed sensor
-      - "0x5902C0003"  # C0003 - Left rear wheel speed sensor
-      - "0x5902C0004"  # C0004 - Right rear wheel speed sensor
+      - "0x59024000"  # C0000 - No fault
+      - "0x59024001"  # C0001 - Left front wheel speed sensor
+      - "0x59024002"  # C0002 - Right front wheel speed sensor
+      - "0x59024003"  # C0003 - Left rear wheel speed sensor
+      - "0x59024004"  # C0004 - Right rear wheel speed sensor
     description: "Read ABS diagnostic trouble codes"
     supports_functional: true  # Supports both physical and functional addressing
 

--- a/config/ecus/engine/ecu_engine_services.yaml
+++ b/config/ecus/engine/ecu_engine_services.yaml
@@ -50,9 +50,9 @@ specific_services:
     request: "0x1902"
     responses:
       - "0x5902"  # No DTCs
-      - "0x5902P0000"  # P0000 - No fault
-      - "0x5902P0100"  # P0100 - Mass or Volume Air Flow Circuit Malfunction
-      - "0x5902P0200"  # P0200 - Injector Circuit Malfunction
+      - "0x59020000"  # P0000 - No fault
+      - "0x59020100"  # P0100 - Mass or Volume Air Flow Circuit Malfunction
+      - "0x59020200"  # P0200 - Injector Circuit Malfunction
     description: "Read engine diagnostic trouble codes"
     supports_functional: true  # Supports both physical and functional addressing
 

--- a/config/ecus/engine/ecu_engine_services_with_delay.yaml
+++ b/config/ecus/engine/ecu_engine_services_with_delay.yaml
@@ -59,11 +59,11 @@ specific_services:
     responses:
       - response: "0x5902"  # No DTCs
         delay_ms: 50
-      - response: "0x5902P0000"  # P0000 - No fault
+      - response: "0x59020000"  # P0000 - No fault
         delay_ms: 100
-      - response: "0x5902P0100"  # P0100 - Mass or Volume Air Flow Circuit Malfunction
+      - response: "0x59020100"  # P0100 - Mass or Volume Air Flow Circuit Malfunction
         delay_ms: 200
-      - response: "0x5902P0200"  # P0200 - Injector Circuit Malfunction
+      - response: "0x59020200"  # P0200 - Injector Circuit Malfunction
         delay_ms: 300
     description: "Read engine diagnostic trouble codes with progressive delays"
     supports_functional: true

--- a/config/ecus/transmission/ecu_transmission_services.yaml
+++ b/config/ecus/transmission/ecu_transmission_services.yaml
@@ -46,9 +46,9 @@ specific_services:
     request: "0x1902"
     responses:
       - "0x5902"  # No DTCs
-      - "0x5902P0700"  # P0700 - Transmission control system
-      - "0x5902P0701"  # P0701 - Transmission control system range/performance
-      - "0x5902P0702"  # P0702 - Transmission control system electrical
+      - "0x59020700"  # P0700 - Transmission control system
+      - "0x59020701"  # P0701 - Transmission control system range/performance
+      - "0x59020702"  # P0702 - Transmission control system electrical
     description: "Read transmission diagnostic trouble codes"
     supports_functional: true  # Supports both physical and functional addressing
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,18 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
+    {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
+]
+
+[[package]]
 name = "authlib"
 version = "1.6.12"
 description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
@@ -485,7 +497,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or os_name == \"nt\" or sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\" or os_name == \"nt\""}
 
 [[package]]
 name = "coverage"
@@ -1107,6 +1119,43 @@ files = [
     {file = "joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241"},
     {file = "joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55"},
 ]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+jsonschema-specifications = ">=2023.3.6"
+referencing = ">=0.28.4"
+rpds-py = ">=0.25.0"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[package.dependencies]
+referencing = ">=0.31.0"
 
 [[package]]
 name = "keyring"
@@ -1963,6 +2012,23 @@ Pygments = ">=2.5.1"
 md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
+
+[[package]]
 name = "regex"
 version = "2025.9.18"
 description = "Alternative regular expression module, to replace re."
@@ -2158,6 +2224,273 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version < \"3.13\""
+files = [
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"},
+    {file = "rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"},
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "python_version >= \"3.13\""
+files = [
+    {file = "rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a"},
+    {file = "rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870"},
+    {file = "rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf"},
+    {file = "rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc"},
+    {file = "rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838"},
+    {file = "rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a"},
+    {file = "rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325"},
+    {file = "rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df"},
+    {file = "rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c"},
+    {file = "rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049"},
+    {file = "rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256"},
+]
 
 [[package]]
 name = "ruamel-yaml"
@@ -2858,4 +3191,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "b198dce3fb696e127ccee3e2081f9629fd5e45ba4d1d15ec763a0283b8cf9567"
+content-hash = "b7ff37e9a87bcfb63afbf3ab2c7c704cbdc8e1a466b7417274c9545183b24ab4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "jinja2>=3.1.0,<4.0.0",
     "python-multipart>=0.0.30,<1.0.0",
     "websockets>=12.0,<15.0",
-    "ruamel-yaml (>=0.19.1,<0.20.0)"
+    "ruamel-yaml (>=0.19.1,<0.20.0)",
+    "jsonschema>=4.23.0,<5.0.0"
 ]
 
 # Project URLs for PyPI

--- a/src/doip_server/config_schema.py
+++ b/src/doip_server/config_schema.py
@@ -1,0 +1,99 @@
+"""JSON Schema validation for DoIP server YAML configuration files.
+
+Validates gateway, ECU, and UDS service configuration files against the
+JSON Schema documents in ``src/doip_server/schemas/``.
+"""
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import yaml
+from jsonschema import Draft202012Validator
+
+SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "schemas")
+
+GATEWAY_SCHEMA_FILE = "gateway.schema.json"
+ECU_SCHEMA_FILE = "ecu.schema.json"
+UDS_SERVICES_SCHEMA_FILE = "uds_services.schema.json"
+
+# Mirrors the patterns in schemas/uds_services.schema.json, for validating
+# UDS request/response strings entered through the web UI.
+HEX_BYTES_RE = re.compile(r"^0[xX]([0-9A-Fa-f]{2})+$")
+REQUEST_RE = re.compile(r"^(0[xX]([0-9A-Fa-f]{2})+|regex:.+)$")
+RESPONSE_RE = re.compile(r"^0[xX]([0-9A-Fa-f]{2}|\{[^{}]*\})+$")
+
+_schema_cache: Dict[str, Dict[str, Any]] = {}
+
+
+def load_schema(schema_file: str) -> Dict[str, Any]:
+    """Load and cache a JSON schema document from ``SCHEMA_DIR``."""
+    if schema_file not in _schema_cache:
+        path = os.path.join(SCHEMA_DIR, schema_file)
+        with open(path, "r") as f:
+            _schema_cache[schema_file] = json.load(f)
+    return _schema_cache[schema_file]
+
+
+@dataclass
+class FileValidationResult:
+    """Result of validating a single YAML file against a schema."""
+
+    path: str
+    schema_file: str
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return not self.errors
+
+
+def validate_yaml_data(data: Any, schema_file: str) -> List[str]:
+    """Validate already-loaded YAML data against *schema_file*.
+
+    Returns a list of human-readable error messages (empty if valid).
+    """
+    validator = Draft202012Validator(load_schema(schema_file))
+    errors = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        location = "/".join(str(p) for p in err.path) or "<root>"
+        errors.append(f"{location}: {err.message}")
+    return errors
+
+
+def validate_yaml_file(path: str, schema_file: str) -> FileValidationResult:
+    """Load *path* as YAML and validate it against *schema_file*."""
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as exc:
+        return FileValidationResult(path, schema_file, [f"Failed to load: {exc}"])
+
+    return FileValidationResult(
+        path, schema_file, validate_yaml_data(data or {}, schema_file)
+    )
+
+
+def validate_config_tree(config_manager) -> List[FileValidationResult]:
+    """Validate every config file known to *config_manager* against its schema.
+
+    Args:
+        config_manager: A ``HierarchicalConfigManager`` instance.
+
+    Returns:
+        List[FileValidationResult]: One result per gateway, ECU, and UDS
+        service file currently loaded.
+    """
+    gateway_path, ecu_paths, service_paths = config_manager.get_config_file_paths()
+
+    results: List[FileValidationResult] = []
+    if gateway_path:
+        results.append(validate_yaml_file(gateway_path, GATEWAY_SCHEMA_FILE))
+    for ecu_path in ecu_paths:
+        results.append(validate_yaml_file(ecu_path, ECU_SCHEMA_FILE))
+    for service_path in service_paths:
+        results.append(validate_yaml_file(service_path, UDS_SERVICES_SCHEMA_FILE))
+
+    return results

--- a/src/doip_server/hierarchical_config_manager.py
+++ b/src/doip_server/hierarchical_config_manager.py
@@ -857,6 +857,7 @@ gateway:
         """Validate all configuration files for completeness and correctness.
 
         This method performs comprehensive validation of all loaded configurations:
+        - JSON Schema validation of every gateway/ECU/UDS service YAML file
         - Gateway configuration (network, protocol settings)
         - ECU configurations (target addresses, tester addresses)
         - UDS services (service definitions)
@@ -869,6 +870,15 @@ gateway:
             Warnings are issued for missing optional configurations,
             errors are issued for missing required configurations.
         """
+        # Validate every config file against its JSON Schema
+        from .config_schema import validate_config_tree
+
+        for result in validate_config_tree(self):
+            if not result.valid:
+                for error in result.errors:
+                    self.logger.error(f"Schema validation ({result.path}): {error}")
+                return False
+
         # Validate gateway configuration
         if not self.gateway_config:
             self.logger.error("Gateway configuration is empty")
@@ -950,6 +960,30 @@ gateway:
 
         self.logger.info("Configuration validation passed")
         return True
+
+    def get_config_file_paths(self) -> Tuple[Optional[str], List[str], List[str]]:
+        """Return the on-disk paths of all configuration files currently loaded.
+
+        Returns:
+            Tuple[Optional[str], List[str], List[str]]: A tuple of
+                (gateway_config_path, ecu_config_paths, uds_service_file_paths),
+                suitable for schema validation of every config file in the
+                hierarchy.
+        """
+        ecu_paths = self._unique_paths(list(self._ecu_file_paths.values()))
+
+        service_paths: List[Optional[str]] = []
+        for ecu_addr, ecu_config in self.ecu_configs.items():
+            ecu_info = ecu_config.get("ecu", {})
+            uds_config = ecu_info.get("uds_services", {})
+            for service_file in uds_config.get("service_files", []):
+                service_paths.append(
+                    self._find_service_file_path(service_file, ecu_addr)
+                )
+
+        service_paths.append(self._find_uds_services_path())
+
+        return self.gateway_config_path, ecu_paths, self._unique_paths(service_paths)
 
     def get_config_summary(self) -> str:
         """Get a summary of the current configuration"""

--- a/src/doip_server/schemas/ecu.schema.json
+++ b/src/doip_server/schemas/ecu.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DoIP ECU Configuration",
+  "type": "object",
+  "required": ["ecu"],
+  "properties": {
+    "ecu": {
+      "type": "object",
+      "required": ["name", "target_address"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "target_address": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "functional_address": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "tester_addresses": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0, "maximum": 65535 }
+        },
+        "settings": { "type": "object", "additionalProperties": true },
+        "routine_activation": { "type": "object", "additionalProperties": true },
+        "uds_services": {
+          "type": "object",
+          "properties": {
+            "service_files": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "common_services": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "specific_services": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/doip_server/schemas/gateway.schema.json
+++ b/src/doip_server/schemas/gateway.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DoIP Gateway Configuration",
+  "type": "object",
+  "required": ["gateway"],
+  "properties": {
+    "gateway": {
+      "type": "object",
+      "required": ["network", "protocol"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "logical_address": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "vehicle": {
+          "type": "object",
+          "properties": {
+            "vin": { "type": "string" },
+            "eid": { "type": "string", "pattern": "^[0-9A-Fa-f]{12}$" },
+            "gid": { "type": "string", "pattern": "^[0-9A-Fa-f]{12}$" }
+          },
+          "additionalProperties": true
+        },
+        "network": {
+          "type": "object",
+          "required": ["host", "port"],
+          "properties": {
+            "host": { "type": "string" },
+            "dual_stack": { "type": "boolean" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "max_connections": { "type": "integer", "minimum": 1 },
+            "timeout": { "type": "number", "exclusiveMinimum": 0 },
+            "keep_alive": { "type": "boolean" },
+            "tcp_nodelay": { "type": "boolean" }
+          },
+          "additionalProperties": true
+        },
+        "protocol": {
+          "type": "object",
+          "required": ["version", "inverse_version"],
+          "properties": {
+            "version": { "type": "integer", "minimum": 0, "maximum": 255 },
+            "inverse_version": { "type": "integer", "minimum": 0, "maximum": 255 }
+          },
+          "additionalProperties": true
+        },
+        "ecus": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "logging": { "type": "object", "additionalProperties": true },
+    "security": { "type": "object", "additionalProperties": true }
+  },
+  "additionalProperties": true
+}

--- a/src/doip_server/schemas/uds_services.schema.json
+++ b/src/doip_server/schemas/uds_services.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DoIP UDS Services Configuration",
+  "type": "object",
+  "$defs": {
+    "hexBytes": {
+      "type": "string",
+      "pattern": "^0[xX]([0-9A-Fa-f]{2})+$",
+      "description": "DoIP/UDS message as a '0x'-prefixed hex string with a whole number of bytes"
+    },
+    "hexBytesOrMirrorTemplate": {
+      "type": "string",
+      "pattern": "^0[xX]([0-9A-Fa-f]{2}|\\{[^{}]*\\})+$",
+      "description": "DoIP/UDS hex string that may embed '{request[...]}' mirroring templates"
+    },
+    "request": {
+      "oneOf": [
+        { "$ref": "#/$defs/hexBytes" },
+        {
+          "type": "string",
+          "pattern": "^regex:.+$",
+          "description": "Regex pattern (prefixed with 'regex:') matched against incoming requests"
+        }
+      ]
+    },
+    "response": {
+      "oneOf": [
+        { "$ref": "#/$defs/hexBytesOrMirrorTemplate" },
+        {
+          "type": "object",
+          "required": ["response"],
+          "properties": {
+            "response": { "$ref": "#/$defs/hexBytesOrMirrorTemplate" },
+            "delay_ms": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "service": {
+      "type": "object",
+      "required": ["request"],
+      "properties": {
+        "request": { "$ref": "#/$defs/request" },
+        "responses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/response" }
+        },
+        "description": { "type": "string" },
+        "supports_functional": { "type": "boolean" },
+        "no_response": { "type": "boolean" },
+        "delay_ms": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "common_services": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/service" }
+    },
+    "specific_services": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/service" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/doip_server/validate_config.py
+++ b/src/doip_server/validate_config.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Command-line configuration validator for the DoIP server.
+
+Validates a gateway configuration and every ECU/UDS service file it
+references, both against their JSON Schemas and against the semantic
+checks performed by ``HierarchicalConfigManager.validate_configs()``.
+
+Usage:
+    python -m doip_server.validate_config [--gateway-config config/gateway1.yaml]
+"""
+
+import argparse
+import sys
+
+from .config_schema import validate_config_tree
+from .hierarchical_config_manager import HierarchicalConfigManager
+
+
+def main() -> None:
+    """Entry point for the ``validate_config`` console script."""
+    parser = argparse.ArgumentParser(
+        description="Validate DoIP server YAML configuration files"
+    )
+    parser.add_argument(
+        "--gateway-config",
+        type=str,
+        default="config/gateway1.yaml",
+        help="Path to the gateway configuration file (default: config/gateway1.yaml)",
+    )
+    args = parser.parse_args()
+
+    config_manager = HierarchicalConfigManager(args.gateway_config)
+
+    schema_results = validate_config_tree(config_manager)
+    schema_ok = True
+    for result in schema_results:
+        if result.valid:
+            print(f"OK    {result.path}")
+        else:
+            schema_ok = False
+            print(f"FAIL  {result.path}")
+            for error in result.errors:
+                print(f"      {error}")
+
+    semantic_ok = config_manager.validate_configs()
+    if semantic_ok:
+        print("OK    semantic validation")
+    else:
+        print("FAIL  semantic validation (see log output above)")
+
+    if schema_ok and semantic_ok:
+        print("\nAll configuration files are valid.")
+        sys.exit(0)
+    else:
+        print("\nConfiguration validation failed.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/web/api/validation.py
+++ b/src/web/api/validation.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, HTTPException
+
+from doip_server.config_schema import validate_config_tree
+from web.state import get_state
+
+router = APIRouter(prefix="/api/validate", tags=["validation"])
+
+
+@router.get("")
+def validate_configuration():
+    cm = get_state().config_manager
+    if cm is None:
+        raise HTTPException(503, "Server not initialised yet")
+
+    results = validate_config_tree(cm)
+    files = [
+        {
+            "path": result.path,
+            "schema": result.schema_file,
+            "valid": result.valid,
+            "errors": result.errors,
+        }
+        for result in results
+    ]
+    semantic_valid = cm.validate_configs()
+
+    return {
+        "valid": semantic_valid and all(f["valid"] for f in files),
+        "semantic_valid": semantic_valid,
+        "files": files,
+    }

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -15,7 +15,7 @@ from fastapi.templating import Jinja2Templates
 # Allow running as `python -m web.app` from src/
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from web.api import doip_client, ecus, gateway, messages, services, status
+from web.api import doip_client, ecus, gateway, messages, services, status, validation
 from web.state import get_state
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -52,6 +52,7 @@ app.include_router(ecus.router)
 app.include_router(services.router)
 app.include_router(messages.router)
 app.include_router(doip_client.router)
+app.include_router(validation.router)
 
 
 # ── HTML page routes ──────────────────────────────────────────────────────────

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -3,6 +3,8 @@
 from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, field_validator
 
+from doip_server.config_schema import REQUEST_RE, RESPONSE_RE
+
 
 class GatewayUpdate(BaseModel):
     name: Optional[str] = None
@@ -33,9 +35,44 @@ class ECUUpdate(BaseModel):
     description: Optional[str] = None
 
 
+def _validate_request(v: str) -> str:
+    if not REQUEST_RE.match(v):
+        raise ValueError(
+            "request must be a '0x'-prefixed hex string with a whole number of "
+            "bytes (e.g. '0x22F190') or a 'regex:' pattern"
+        )
+    return v
+
+
+def _validate_response(v: str) -> str:
+    if not RESPONSE_RE.match(v):
+        raise ValueError(
+            "response must be a '0x'-prefixed hex string with a whole number of "
+            "bytes (e.g. '0x62F190'), optionally containing '{request[...]}' "
+            "mirroring templates"
+        )
+    return v
+
+
+def _validate_responses(
+    responses: Optional[List[Union[str, "ServiceResponse"]]],
+) -> Optional[List[Union[str, "ServiceResponse"]]]:
+    if responses is None:
+        return responses
+    for entry in responses:
+        if isinstance(entry, str):
+            _validate_response(entry)
+    return responses
+
+
 class ServiceResponse(BaseModel):
     response: str
     delay_ms: Optional[int] = None
+
+    @field_validator("response")
+    @classmethod
+    def validate_response(cls, v: str) -> str:
+        return _validate_response(v)
 
 
 class ServiceCreate(BaseModel):
@@ -46,6 +83,18 @@ class ServiceCreate(BaseModel):
     no_response: bool = False
     delay_ms: int = 0
 
+    @field_validator("request")
+    @classmethod
+    def validate_request(cls, v: str) -> str:
+        return _validate_request(v)
+
+    @field_validator("responses")
+    @classmethod
+    def validate_responses(
+        cls, v: List[Union[str, ServiceResponse]]
+    ) -> List[Union[str, ServiceResponse]]:
+        return _validate_responses(v)
+
 
 class ServiceUpdate(BaseModel):
     request: Optional[str] = None
@@ -54,6 +103,20 @@ class ServiceUpdate(BaseModel):
     supports_functional: Optional[bool] = None
     no_response: Optional[bool] = None
     delay_ms: Optional[int] = None
+
+    @field_validator("request")
+    @classmethod
+    def validate_request(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        return _validate_request(v)
+
+    @field_validator("responses")
+    @classmethod
+    def validate_responses(
+        cls, v: Optional[List[Union[str, ServiceResponse]]]
+    ) -> Optional[List[Union[str, ServiceResponse]]]:
+        return _validate_responses(v)
 
 
 class DoIPSendRequest(BaseModel):

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -58,6 +58,37 @@ document.body.addEventListener("htmx:beforeSwap", function (evt) {
         </div>`).join("");
   }
 
+  if (id === "validation-results") {
+    const files = Array.isArray(data.files) ? data.files : [];
+    const overall = data.valid
+      ? `<span class="text-green-400">All configuration files are valid.</span>`
+      : `<span class="text-red-400">Configuration validation failed.</span>`;
+
+    const rows = files.map((f) => {
+      const status = f.valid
+        ? `<span class="text-green-400">OK</span>`
+        : `<span class="text-red-400">FAIL</span>`;
+      const errors = Array.isArray(f.errors) && f.errors.length
+        ? `<ul class="mt-1 ml-4 list-disc text-red-300">${f.errors.map((e) => `<li>${esc(e)}</li>`).join("")}</ul>`
+        : "";
+      return `<div class="py-1 border-b border-gray-700/60">
+          <div>${status} <span class="text-gray-300">${esc(f.path)}</span></div>
+          ${errors}
+        </div>`;
+    }).join("");
+
+    const semantic = data.semantic_valid
+      ? `<span class="text-green-400">OK</span>`
+      : `<span class="text-red-400">FAIL</span>`;
+
+    evt.detail.serverResponse = `
+      <div class="mb-2">${overall}</div>
+      ${rows}
+      <div class="mt-2 pt-2 border-t border-gray-700">
+        ${semantic} <span class="text-gray-300">Semantic validation</span>
+      </div>`;
+  }
+
   if (id === "gateway-data") {
     // Swapped with innerHTML into #gateway-data: return ONLY the inner content.
     // Re-emitting a #gateway-data wrapper with hx-trigger="load" caused infinite

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -54,4 +54,19 @@
     Loading…
   </div>
 </section>
+
+<!-- Configuration validation -->
+<section class="mt-8">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="font-bold text-gray-300">Configuration Validation</h2>
+    <button class="text-xs px-3 py-1 bg-blue-700 hover:bg-blue-600 rounded"
+            hx-get="/api/validate"
+            hx-target="#validation-results"
+            hx-swap="innerHTML">Run Validation</button>
+  </div>
+  <div id="validation-results"
+       class="bg-gray-800 rounded border border-gray-700 p-4 text-xs leading-6 text-gray-400">
+    Click "Run Validation" to check all configuration files against their schemas.
+  </div>
+</section>
 {% endblock %}

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,138 @@
+"""Tests for the JSON Schema config validator (doip_server.config_schema)."""
+
+import pytest
+
+from doip_server.config_schema import (
+    ECU_SCHEMA_FILE,
+    GATEWAY_SCHEMA_FILE,
+    UDS_SERVICES_SCHEMA_FILE,
+    validate_config_tree,
+    validate_yaml_data,
+    validate_yaml_file,
+)
+from doip_server.hierarchical_config_manager import HierarchicalConfigManager
+
+
+@pytest.mark.unit
+def test_valid_gateway_data_passes():
+    data = {
+        "gateway": {
+            "network": {"host": "0.0.0.0", "port": 13400},
+            "protocol": {"version": 0x02, "inverse_version": 0xFD},
+        }
+    }
+    assert validate_yaml_data(data, GATEWAY_SCHEMA_FILE) == []
+
+
+@pytest.mark.unit
+def test_invalid_gateway_data_missing_required():
+    data = {"gateway": {"network": {"host": "0.0.0.0", "port": 13400}}}
+    errors = validate_yaml_data(data, GATEWAY_SCHEMA_FILE)
+    assert errors
+    assert any("protocol" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_invalid_ecu_data_missing_target_address():
+    data = {"ecu": {"name": "Engine"}}
+    errors = validate_yaml_data(data, ECU_SCHEMA_FILE)
+    assert any("target_address" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_valid_uds_service_hex_request():
+    data = {
+        "common_services": {
+            "Test_Service": {
+                "request": "0x22F190",
+                "responses": ["0x62F19012345678"],
+            }
+        }
+    }
+    assert validate_yaml_data(data, UDS_SERVICES_SCHEMA_FILE) == []
+
+
+@pytest.mark.unit
+def test_invalid_uds_service_bad_hex_request():
+    data = {
+        "common_services": {
+            "Test_Service": {
+                "request": "0x22GG",
+                "responses": ["0x62F190"],
+            }
+        }
+    }
+    errors = validate_yaml_data(data, UDS_SERVICES_SCHEMA_FILE)
+    assert errors
+    assert any("request" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_uds_service_regex_request_is_valid():
+    data = {
+        "common_services": {
+            "Test_Service": {
+                "request": "regex:^10[0-9A-F]{2}$",
+                "responses": ["0x5010"],
+            }
+        }
+    }
+    assert validate_yaml_data(data, UDS_SERVICES_SCHEMA_FILE) == []
+
+
+@pytest.mark.unit
+def test_uds_service_mirroring_response_is_valid():
+    data = {
+        "specific_services": {
+            "Test_Mirroring": {
+                "request": "0x220C01",
+                "responses": ["0x620C01{request[2:4]}"],
+            }
+        }
+    }
+    assert validate_yaml_data(data, UDS_SERVICES_SCHEMA_FILE) == []
+
+
+@pytest.mark.unit
+def test_validate_yaml_file_missing_file():
+    result = validate_yaml_file("config/does_not_exist.yaml", GATEWAY_SCHEMA_FILE)
+    assert not result.valid
+    assert "Failed to load" in result.errors[0]
+
+
+@pytest.mark.unit
+def test_validate_config_tree_for_real_config():
+    cm = HierarchicalConfigManager("config/gateway1.yaml")
+    results = validate_config_tree(cm)
+    assert results
+    for result in results:
+        assert result.valid, f"{result.path}: {result.errors}"
+
+
+@pytest.mark.unit
+def test_get_config_file_paths():
+    cm = HierarchicalConfigManager("config/gateway1.yaml")
+    gateway_path, ecu_paths, service_paths = cm.get_config_file_paths()
+
+    assert gateway_path == "config/gateway1.yaml"
+    assert len(ecu_paths) == len(cm.ecu_configs)
+    assert all(p.endswith(".yaml") for p in ecu_paths)
+    assert service_paths
+    assert all(p.endswith(".yaml") for p in service_paths)
+
+
+@pytest.mark.unit
+def test_validate_configs_fails_on_schema_error(tmp_path, monkeypatch):
+    cm = HierarchicalConfigManager("config/gateway1.yaml")
+
+    # validate_config_tree validates files on disk, so point it at a file
+    # containing an invalid UDS service definition.
+    bad_file = tmp_path / "bad_services.yaml"
+    bad_file.write_text("common_services:\n  Bad_Service:\n    request: 'not_hex'\n")
+    monkeypatch.setattr(
+        cm,
+        "get_config_file_paths",
+        lambda: ("config/gateway1.yaml", [], [str(bad_file)]),
+    )
+
+    assert cm.validate_configs() is False

--- a/tests/test_validate_config_cli.py
+++ b/tests/test_validate_config_cli.py
@@ -1,0 +1,36 @@
+"""Tests for the `validate_config` CLI entry point."""
+
+import pytest
+
+from doip_server import validate_config
+
+
+@pytest.mark.unit
+def test_main_succeeds_for_valid_config(capsys, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["validate_config"])
+
+    with pytest.raises(SystemExit) as exc:
+        validate_config.main()
+    assert exc.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "All configuration files are valid." in captured.out
+    assert "OK    config/gateway1.yaml" in captured.out
+
+
+@pytest.mark.unit
+def test_main_fails_for_invalid_config(tmp_path, capsys, monkeypatch):
+    bad_gateway = tmp_path / "bad_gateway.yaml"
+    bad_gateway.write_text("gateway:\n  network:\n    host: '0.0.0.0'\n")
+
+    monkeypatch.setattr(
+        "sys.argv", ["validate_config", "--gateway-config", str(bad_gateway)]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        validate_config.main()
+    assert exc.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.out
+    assert "Configuration validation failed." in captured.out

--- a/tests/test_web/test_api_services.py
+++ b/tests/test_web/test_api_services.py
@@ -93,3 +93,58 @@ def test_update_missing_service(web_client):
         f"/api/ecus/{addr}/services/__no_such__", json={"description": "x"}
     )
     assert r.status_code == 404
+
+
+@pytest.mark.unit
+def test_create_service_rejects_invalid_request_hex(web_client):
+    addr = _first_ecu(web_client)
+    payload = {"request": "not_hex", "responses": ["0x62AABB00"]}
+    r = web_client.post(
+        f"/api/ecus/{addr}/services?service_name=bad_request_service", json=payload
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_create_service_rejects_invalid_response_hex(web_client):
+    addr = _first_ecu(web_client)
+    payload = {"request": "0x22AABB", "responses": ["not_hex"]}
+    r = web_client.post(
+        f"/api/ecus/{addr}/services?service_name=bad_response_service", json=payload
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_create_service_allows_regex_request(web_client):
+    addr = _first_ecu(web_client)
+    svc_name = "regex_request_service"
+    payload = {"request": "regex:^10[0-9A-F]{2}$", "responses": ["0x5010"]}
+    r = web_client.post(
+        f"/api/ecus/{addr}/services?service_name={svc_name}", json=payload
+    )
+    assert r.status_code == 201
+
+    web_client.delete(f"/api/ecus/{addr}/services/{svc_name}")
+
+
+@pytest.mark.unit
+def test_create_service_allows_mirroring_response(web_client):
+    addr = _first_ecu(web_client)
+    svc_name = "mirroring_response_service"
+    payload = {"request": "0x220C01", "responses": ["0x620C01{request[2:4]}"]}
+    r = web_client.post(
+        f"/api/ecus/{addr}/services?service_name={svc_name}", json=payload
+    )
+    assert r.status_code == 201
+
+    web_client.delete(f"/api/ecus/{addr}/services/{svc_name}")
+
+
+@pytest.mark.unit
+def test_update_service_rejects_invalid_request_hex(web_client):
+    addr = _first_ecu(web_client)
+    services = web_client.get(f"/api/ecus/{addr}/services").json()
+    name = services[0]["name"]
+    r = web_client.put(f"/api/ecus/{addr}/services/{name}", json={"request": "not_hex"})
+    assert r.status_code == 422

--- a/tests/test_web/test_api_validation.py
+++ b/tests/test_web/test_api_validation.py
@@ -1,0 +1,17 @@
+"""Tests for GET /api/validate."""
+
+import pytest
+
+
+@pytest.mark.unit
+def test_validate_endpoint_ok(web_client):
+    r = web_client.get("/api/validate")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["valid"] is True
+    assert data["semantic_valid"] is True
+    assert isinstance(data["files"], list)
+    assert data["files"]
+    for entry in data["files"]:
+        assert entry["valid"] is True
+        assert entry["errors"] == []


### PR DESCRIPTION
## Summary
- Add JSON Schema documents (`src/doip_server/schemas/`) for gateway, ECU, and UDS service YAML configuration files, including support for `regex:` request patterns and `{request[...]}` mirroring response templates.
- Add `src/doip_server/config_schema.py` validator module (`validate_yaml_file`, `validate_yaml_data`, `validate_config_tree`).
- Add `HierarchicalConfigManager.get_config_file_paths()` and integrate schema validation into `validate_configs()` (runs at server startup).
- Add `validate_config` CLI entry point (`src/doip_server/validate_config.py`) and `make validate-config` target.
- Add `GET /api/validate` endpoint and a "Configuration Validation" panel on the web dashboard.
- Add hex/regex/mirroring-template validators to `ServiceCreate`/`ServiceUpdate`/`ServiceResponse` in `src/web/models.py` so invalid UDS request/response strings entered through the web UI are rejected.
- Fix invalid DTC hex placeholders (e.g. `"0x5902P0000"`, `"0x5902C0000"`) in engine/transmission/ABS service configs, found by the new schema validation.
- Add `jsonschema` dependency.

Closes #120.

## Test plan
- [x] `poetry run pytest tests/` — 368 passed, 5 skipped
- [x] `make validate-config` — all 18 config files + semantic checks pass
- [x] `poetry run black --check` / `flake8` on touched files